### PR TITLE
Add Nginx URL Rewrite Rules for Laravel Project with Livewire and/or Filament PHP

### DIFF
--- a/static/rewrite/laravel-filamentphp.conf
+++ b/static/rewrite/laravel-filamentphp.conf
@@ -1,0 +1,7 @@
+location / {
+    try_files $uri $uri/ /index.php$is_args$query_string;
+}
+
+location ~ ^/(filament|livewire) {
+    try_files $uri $uri/ /index.php$is_args$query_string;
+}

--- a/static/rewrite/laravel-livewire.conf
+++ b/static/rewrite/laravel-livewire.conf
@@ -1,0 +1,7 @@
+location / {
+    try_files $uri $uri/ /index.php$is_args$query_string;
+}
+
+location ^~ /livewire {
+    try_files $uri $uri/ /index.php$is_args$query_string;
+}


### PR DESCRIPTION
# Description

This pull request introduces two new common Nginx URL rewrite rules in the hosts editor:

## Laravel with Livewire

Adds URL rewrite rules necessary for handling Livewire requests.

    location / {
        try_files $uri $uri/ /index.php$is_args$query_string;
    }

    location ^~ /livewire {
        try_files $uri $uri/ /index.php?$query_string;
    }

## Laravel with Filament PHP

Adds URL rewrite rules necessary for handling of FilamentPHP requests.

    location / {
        try_files $uri $uri/ /index.php$is_args$query_string;
    }

    location ~ ^/(filament|livewire) {
        try_files $uri $uri/ /index.php$is_args$query_string;
    }

##purpose

These URL rewrite rules aim to streamline the setup process for developers using Laravel with Livewire or Filament PHP, reducing the need for manual configuration.