### PR TITLE
* Fix node-pty compiling struggles

### DIFF
--- a/build/afterPack.js
+++ b/build/afterPack.js
@@ -17,7 +17,6 @@ exports.default = async function after(pack) {
     ] = `/opt:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:${optdefault.env['PATH']}`
   }
   execSync('asar e app.asar app', optdefault)
-  execSync('rm -rf app/node_modules/node-pty/build/node_gyp_bins', optdefault)
   execSync('rm -rf app.asar', optdefault)
   execSync('asar pack app app.asar', optdefault)
   execSync('rm -rf app', optdefault)

--- a/configs/esbuild.config.ts
+++ b/configs/esbuild.config.ts
@@ -4,7 +4,7 @@ const external = [
   'electron',
   'path',
   'fs',
-  'node-pty',
+  '@lydell/node-pty',
   'fsevents',
   'mock-aws-s3',
   'aws-sdk',

--- a/configs/vite.config.ts
+++ b/configs/vite.config.ts
@@ -28,7 +28,7 @@ const config: UserConfig = {
       'electron',
       'path',
       'fs',
-      'node-pty',
+      '@lydell/node-pty',
       'fsevents',
       'mock-aws-s3',
       'aws-sdk',

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "web": "vite -c web/vite.config.ts",
     "web-build": "vite -c web/vite.config.ts build",
     "dev": "npm run build-dev-runner && cross-env NODE_ENV=development TEST=electron node electron/dev-runner.js",
-    "clean:dev": "rd /s /q dist",
-    "clean": "rd /s /q dist && rd /s /q node_modules/node-pty/build",
+    "clean": "rd /s /q dist",
     "build": "npx esbuild --platform=node --bundle --external:vite --external:esbuild --external:electron-builder --external:consolidate --external:@vue/compiler-sfc scripts/app-builder.ts --outfile=electron/app-builder.js && cross-env NODE_ENV=production node electron/app-builder.js",
     "postinstall": "electron-builder install-app-deps"
   },
@@ -25,6 +24,7 @@
   "dependencies": {
     "7zip-min-electron": "^1.4.4",
     "@electron/remote": "^2.0.9",
+    "@lydell/node-pty": "^1.1.0",
     "@lzwme/get-physical-address": "^1.1.0",
     "axios": "^1.7.7",
     "chardet": "^2.1.0",
@@ -45,7 +45,6 @@
     "lodash": "^4.17.21",
     "node-forge": "^1.3.1",
     "node-machine-id": "^1.1.12",
-    "node-pty": "^1.0.0",
     "node-rsa": "^1.1.1",
     "normalize.css": "^8.0.1",
     "npm-check-updates": "^17.1.18",

--- a/src/main/core/NodePTY.ts
+++ b/src/main/core/NodePTY.ts
@@ -1,6 +1,8 @@
 import type { PtyItem } from '../type'
+import type { IPty } from '@lydell/node-pty'
+
 import { uuid } from '../utils'
-import type { spawn, IPty } from '@lydell/node-pty'
+import { spawn } from '@lydell/node-pty'
 
 class NodePTY {
   pty: Partial<Record<string, PtyItem>> = {}

--- a/src/main/core/NodePTY.ts
+++ b/src/main/core/NodePTY.ts
@@ -1,7 +1,6 @@
 import type { PtyItem } from '../type'
 import { uuid } from '../utils'
-import type { IPty } from 'node-pty'
-import { spawn } from 'node-pty'
+import type { spawn, IPty } from '@lydell/node-pty'
 
 class NodePTY {
   pty: Partial<Record<string, PtyItem>> = {}

--- a/src/main/type.d.ts
+++ b/src/main/type.d.ts
@@ -1,5 +1,5 @@
 import { Server } from 'http'
-import type { IPty } from 'node-pty'
+import type { IPty } from '@lydell/node-pty'
 
 export interface StaticHttpServe {
   server: Server


### PR DESCRIPTION
Precompiled library @lydell/node-pty using modern version 1.1.0

Fixes a ton load of struggles and build errors:
* Removes the requirement of installing build tools
* Fix requirement of running build process as Admin
* Escapes problem with node-gyp not being able to build in projects containing spaces in path

(cherry picked from commit 6121eeb67dfbb6974fddae72a6df319a2d19853c)