### PR TITLE
add text indication text to the folder is for custom *.conf

### DIFF
--- a/src/lang/en/base.json
+++ b/src/lang/en/base.json
@@ -10,6 +10,7 @@
   "del": "Delete",
   "version": "Version",
   "commonTemplates": "Common Templates",
+  "customConf": "Custom *.conf",
   "save": "Save",
   "lang": "Language",
   "changeLang": "Change Language",

--- a/src/lang/fr/base.json
+++ b/src/lang/fr/base.json
@@ -10,6 +10,7 @@
   "del": "Supprimer",
   "version": "Version",
   "commonTemplates": "Modèles communs",
+  "customConf": "*.conf personnalisé",
   "save": "Enregistrer",
   "lang": "Langue",
   "changeLang": "Changer la langue",

--- a/src/lang/id/base.json
+++ b/src/lang/id/base.json
@@ -10,6 +10,7 @@
   "del": "Hapus",
   "version": "Versi",
   "commonTemplates": "Template Umum",
+  "customConf": "*.conf Kustom",
   "save": "Simpan",
   "lang": "Bahasa",
   "changeLang": "Ganti Bahasa",

--- a/src/lang/it/base.json
+++ b/src/lang/it/base.json
@@ -10,6 +10,7 @@
   "del": "Elimina",
   "version": "Versione",
   "commonTemplates": "Template comuni",
+  "customConf": "*.conf personalizzato",
   "save": "Salva",
   "lang": "Lingua",
   "changeLang": "Cambia lingua",

--- a/src/lang/sv/base.json
+++ b/src/lang/sv/base.json
@@ -10,6 +10,7 @@
   "del": "Radera",
   "version": "Version",
   "commonTemplates": "Vanliga mallar",
+  "customConf": "Anpassad *.conf",
   "save": "Spara",
   "lang": "Språk",
   "changeLang": "Byt språk",

--- a/src/lang/tr/base.json
+++ b/src/lang/tr/base.json
@@ -10,6 +10,7 @@
   "del": "Sil",
   "version": "Sürüm",
   "commonTemplates": "Genel Şablonlar",
+  "customConf": "Özel *.conf",
   "save": "Kaydet",
   "lang": "Dil",
   "changeLang": "Dili Değiştir",

--- a/src/lang/vi/base.json
+++ b/src/lang/vi/base.json
@@ -9,6 +9,7 @@
   "del": "Xóa",
   "version": "Phiên bản",
   "commonTemplates": "Các mẫu chung",
+  "customConf": "*.conf tùy chỉnh",
   "save": "Lưu",
   "lang": "Ngôn ngữ",
   "changeLang": "Thay đổi ngôn ngữ",

--- a/src/lang/zh/base.json
+++ b/src/lang/zh/base.json
@@ -10,6 +10,7 @@
   "del": "删除",
   "version": "版本",
   "commonTemplates": "常用模板",
+  "customConf": "自定义 *.conf",
   "save": "保存",
   "lang": "语言",
   "changeLang": "更改语言",

--- a/src/render/components/Host/Edit/nginxRewrite.vue
+++ b/src/render/components/Host/Edit/nginxRewrite.vue
@@ -65,7 +65,9 @@
       <el-button
         :icon="FolderOpened"
         @click.stop="shell.openPath(nginxRewriteTemplateDir)"
-      ></el-button>
+      >
+        {{ I18nT('base.customConf') }}
+      </el-button>
     </div>
     <div ref="input" class="input-textarea nginx-rewrite"></div>
   </div>


### PR DESCRIPTION
User can import from conf those haven't relase https://github.com/xpf0000/FlyEnv/tree/master/static/rewrite

I am looking for laravel+livewire rewrite template, I found in the static, but the folder icon did not indate clearly. I hope to add this indication to allow people know they can add their own conf file