### PR TITLE
fix: attr name repeate of newProject in winOS at phpCrate.win.vue

### DIFF
--- a/src/render/components/Host/CreateProject/phpCreate.win.vue
+++ b/src/render/components/Host/CreateProject/phpCreate.win.vue
@@ -69,7 +69,7 @@
             </div>
             <div class="park">
               <div class="title">
-                <span>{{ I18nT('host.phpVersion') }}</span>
+                <span>{{ I18nT('host.frameworkVersion') }}</span>
               </div>
               <el-select
                 v-model="ProjectSetup.form.PHP.version"


### PR DESCRIPTION
fix: attr name repeate of newProject in winOS at phpCrate.win.vue