### PR TITLE
feat(jwt): Added JWT encoding and decoding tool components

### DIFF
--- a/src/lang/ar/tools.json
+++ b/src/lang/ar/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "ترميز/فك ترميز كيانات HTML",
   "git-cheatsheet-title": "ورقة غش Git",
   "hash-text-title": "تجزئة سلسلة نصية (Hash String)",
+  "jwt-title": "ترميز/فك ترميز JWT",
   "http-status-codes-title": "رموز حالة HTTP",
   "keycode-info-title": "معلومات رمز المفتاح (Keycode Info)",
   "mime-types-title": "أنواع MIME",

--- a/src/lang/az/tools.json
+++ b/src/lang/az/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML Qaçış",
   "git-cheatsheet-title": "GIT Qısa Bələdçi",
   "hash-text-title": "Mətni Hash Et",
+  "jwt-title": "JWT Kodlaşdırma/Deşifrə",
   "http-status-codes-title": "HTTP Status Kodları",
   "keycode-info-title": "Açar Kodu Məlumatı",
   "mime-types-title": "MIME Tipləri",

--- a/src/lang/bg/tools.json
+++ b/src/lang/bg/tools.json
@@ -27,6 +27,7 @@
   "escape-html-title": "HTML Entity Encode/Decode",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash String",
+  "jwt-title": "JWT кодиране/декодиране",
   "http-status-codes-title": "HTTP Status Codes",
   "keycode-info-title": "Keycode Info",
   "mime-types-title": "MIME Types",

--- a/src/lang/bn/tools.json
+++ b/src/lang/bn/tools.json
@@ -26,6 +26,7 @@
   "git-cheatsheet-title": "Git চিটশিট",
   "hash-text-title": "হ্যাশ স্ট্রিং",
   "http-status-codes-title": "HTTP স্ট্যাটাস কোড",
+  "jwt-title": "JWT এনকোড/ডিকোড",
   "keycode-info-title": "কীকোড তথ্য",
   "mime-types-title": "MIME টাইপ",
   "qr-code-generator-title": "QR কোড জেনারেটর",

--- a/src/lang/cs/tools.json
+++ b/src/lang/cs/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML kódování/dekódování entity",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash řetězec",
+  "jwt-title": "JWT kódování/dekódování",
   "http-status-codes-title": "Stavové kódy HTTP",
   "keycode-info-title": "Informace o klíčovém kódu",
   "mime-types-title": "MIME typy",

--- a/src/lang/da/tools.json
+++ b/src/lang/da/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Html Entity Encode/Decode",
   "git-cheatsheet-title": "Git Snydeark",
   "hash-text-title": "Hash Streng",
+  "jwt-title": "JWT kodning/afkodning",
   "http-status-codes-title": "Http Statuskoder",
   "keycode-info-title": "Nøglekode Info",
   "mime-types-title": "MIME Typer",

--- a/src/lang/de/tools.json
+++ b/src/lang/de/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML-Entitäts-Codierung/Dekodierung",
   "git-cheatsheet-title": "Git-Spickzettel",
   "hash-text-title": "Hash-String",
+  "jwt-title": "JWT kodieren/dekodieren",
   "http-status-codes-title": "HTTP Statuscodes",
   "keycode-info-title": "Keycode Info",
   "mime-types-title": "MIME-Typen",

--- a/src/lang/el/tools.json
+++ b/src/lang/el/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Κωδικοποίηση Οντότητας Html/Αποκωδικοποίηση",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Συμβολοσειρά Hash",
+  "jwt-title": "Κωδικοποίηση/αποκωδικοποίηση JWT",
   "http-status-codes-title": "Κωδικοί Κατάστασης HTTP",
   "keycode-info-title": "Πληροφορίες Κωδικού",
   "mime-types-title": "Τύποι MIME",

--- a/src/lang/en/tools.json
+++ b/src/lang/en/tools.json
@@ -27,6 +27,7 @@
   "escape-html-title": "HTML Entity Encode/Decode",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash String",
+  "jwt-title": "JWT Encode/Decode",
   "http-status-codes-title": "HTTP Status Codes",
   "keycode-info-title": "Keycode Info",
   "mime-types-title": "MIME Types",

--- a/src/lang/es/tools.json
+++ b/src/lang/es/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Codificar/Decodificar Entidades HTML",
   "git-cheatsheet-title": "Hoja de Referencia Git",
   "hash-text-title": "Cadena de Hash",
+  "jwt-title": "Codificar/decodificar JWT",
   "http-status-codes-title": "Códigos de Estado HTTP",
   "keycode-info-title": "Información de Código de Tecla",
   "mime-types-title": "Tipos MIME",

--- a/src/lang/fi/tools.json
+++ b/src/lang/fi/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Html Entity Encode/Decode",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash Merkkijono",
+  "jwt-title": "JWT-koodaus/purku",
   "http-status-codes-title": "Http Tilan Koodit",
   "keycode-info-title": "Avainkoodin Tiedot",
   "mime-types-title": "MIME-tyypit",

--- a/src/lang/fr/tools.json
+++ b/src/lang/fr/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Échappement HTML",
   "git-cheatsheet-title": "Feuille de triche GIT",
   "hash-text-title": "Hacher du texte",
+  "jwt-title": "Encodage/décodage JWT",
   "http-status-codes-title": "Codes d'état HTTP",
   "keycode-info-title": "Informations Keycode",
   "mime-types-title": "Types MIME",

--- a/src/lang/id/tools.json
+++ b/src/lang/id/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Pelepasan HTML",
   "git-cheatsheet-title": "Lembar contekan GIT",
   "hash-text-title": "Hash Teks",
+  "jwt-title": "Encode/Decode JWT",
   "http-status-codes-title": "Kode Status HTTP",
   "keycode-info-title": "Info Keycode",
   "mime-types-title": "Jenis MIME",

--- a/src/lang/it/tools.json
+++ b/src/lang/it/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Escape HTML",
   "git-cheatsheet-title": "Foglio illustrativo GIT",
   "hash-text-title": "Hash testo",
+  "jwt-title": "Codifica/decodifica JWT",
   "http-status-codes-title": "Codici di stato HTTP",
   "keycode-info-title": "Informazioni Keycode",
   "mime-types-title": "Tipi MIME",

--- a/src/lang/ja/tools.json
+++ b/src/lang/ja/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTMLエスケープ",
   "git-cheatsheet-title": "GITチートシート",
   "hash-text-title": "テキストをハッシュ化",
+  "jwt-title": "JWT エンコード/デコード",
   "http-status-codes-title": "HTTPステータスコード",
   "keycode-info-title": "キーコード情報",
   "mime-types-title": "MIMEタイプ",

--- a/src/lang/nl/tools.json
+++ b/src/lang/nl/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML Entiteit Versleutelen/Decode",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash String",
+  "jwt-title": "JWT coderen/decoderen",
   "http-status-codes-title": "HTTP Status Codes",
   "keycode-info-title": "Toetsencode informatie",
   "mime-types-title": "MIME-typen",

--- a/src/lang/no/tools.json
+++ b/src/lang/no/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML enhet/dekode",
   "git-cheatsheet-title": "Git Cheatsheet",
   "hash-text-title": "Hash streng",
+  "jwt-title": "JWT koding/dekoding",
   "http-status-codes-title": "HTTP-statuskoder",
   "keycode-info-title": "Informasjon om nøkkelkode",
   "mime-types-title": "MIME-typer",

--- a/src/lang/pl/tools.json
+++ b/src/lang/pl/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Kodowanie jednostki HTML",
   "git-cheatsheet-title": "Arkusz oszustw Git",
   "hash-text-title": "Ciąg haseł",
+  "jwt-title": "Kodowanie/dekodowanie JWT",
   "http-status-codes-title": "Kody statusu HTTP",
   "keycode-info-title": "Informacje o kodzie klucza",
   "mime-types-title": "Rodzaje MIME",

--- a/src/lang/pt-br/tools.json
+++ b/src/lang/pt-br/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Escape HTML",
   "git-cheatsheet-title": "Folha de dicas GIT",
   "hash-text-title": "Hash Texto",
+  "jwt-title": "Codificar/decodificar JWT",
   "http-status-codes-title": "Códigos de status HTTP",
   "keycode-info-title": "Informações de Keycode",
   "mime-types-title": "Tipos MIME",

--- a/src/lang/pt/tools.json
+++ b/src/lang/pt/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Escape HTML",
   "git-cheatsheet-title": "Folha de dicas GIT",
   "hash-text-title": "Texto Hash",
+  "jwt-title": "Codificar/decodificar JWT",
   "http-status-codes-title": "Códigos de estado HTTP",
   "keycode-info-title": "Informações de Keycode",
   "mime-types-title": "Tipos MIME",

--- a/src/lang/ro/tools.json
+++ b/src/lang/ro/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Cod HTML de entitate/decodare",
   "git-cheatsheet-title": "Git foi de încălzire",
   "hash-text-title": "Șir de Hash",
+  "jwt-title": "Codificare/decodificare JWT",
   "http-status-codes-title": "Coduri de stare HTTP",
   "keycode-info-title": "Informații cod cheie",
   "mime-types-title": "Tipuri MIME",

--- a/src/lang/ru/tools.json
+++ b/src/lang/ru/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML-код сущности/декодирование",
   "git-cheatsheet-title": "Чит-лист Git",
   "hash-text-title": "Хэш строка",
+  "jwt-title": "Кодирование/декодирование JWT",
   "http-status-codes-title": "Код состояния HTTP",
   "keycode-info-title": "Информация о ключевом коде",
   "mime-types-title": "Типы MIME",

--- a/src/lang/sv/tools.json
+++ b/src/lang/sv/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML-escapering",
   "git-cheatsheet-title": "GIT-fusklapp",
   "hash-text-title": "Hash-text",
+  "jwt-title": "JWT-kodning/avkodning",
   "http-status-codes-title": "HTTP-statuskoder",
   "keycode-info-title": "Tangentkodsinformation",
   "mime-types-title": "MIME-typer",

--- a/src/lang/tr/tools.json
+++ b/src/lang/tr/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML Kaçış",
   "git-cheatsheet-title": "GIT Hile Sayfası",
   "hash-text-title": "Metni Hash Et",
+  "jwt-title": "JWT Kodlama/Kod Çözme",
   "http-status-codes-title": "HTTP Durum Kodları",
   "keycode-info-title": "Keycode Bilgisi",
   "mime-types-title": "MIME Türleri",

--- a/src/lang/uk/tools.json
+++ b/src/lang/uk/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Кодування/декодування HTML-сутності",
   "git-cheatsheet-title": "Шпаргалка Git",
   "hash-text-title": "Хеш-рядок",
+  "jwt-title": "Кодування/декодування JWT",
   "http-status-codes-title": "Статус HTTP Коди",
   "keycode-info-title": "Інформація про ключовий код",
   "mime-types-title": "Типи MIME",

--- a/src/lang/vi/tools.json
+++ b/src/lang/vi/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "Mã hóa/Giải mã thực thể HTML",
   "git-cheatsheet-title": "Bảng tóm tắt Git",
   "hash-text-title": "Chuỗi băm",
+  "jwt-title": "Mã hóa/giải mã JWT",
   "http-status-codes-title": "Mã trạng thái HTTP",
   "keycode-info-title": "Thông tin Keycode",
   "mime-types-title": "Các loại MIME",

--- a/src/lang/zh-hant/tools.json
+++ b/src/lang/zh-hant/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML 跳脫",
   "git-cheatsheet-title": "GIT 備忘錄",
   "hash-text-title": "Hash 文字",
+  "jwt-title": "JWT 編碼/解碼",
   "http-status-codes-title": "HTTP 狀態碼",
   "keycode-info-title": "Keycode 資訊",
   "mime-types-title": "MIME 類型",

--- a/src/lang/zh/tools.json
+++ b/src/lang/zh/tools.json
@@ -25,6 +25,7 @@
   "escape-html-title": "HTML转义",
   "git-cheatsheet-title": "GIT备忘录",
   "hash-text-title": "Hash 文本",
+  "jwt-title": "JWT 编码/解码",
   "http-status-codes-title": "HTTP状态码",
   "keycode-info-title": "Keycode信息",
   "mime-types-title": "MIME类型",

--- a/src/render/components/Tools/JWT/Index.vue
+++ b/src/render/components/Tools/JWT/Index.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import Store from './store'
+import { I18nT } from '@lang/index'
+</script>
+
+<template>
+  <div class="host-edit tools">
+    <div class="nav p-0">
+      <div class="left">
+        <span class="text-xl">{{ I18nT('tools.jwt-title') }}</span>
+        <slot name="like"></slot>
+      </div>
+    </div>
+
+    <el-scrollbar class="flex-1">
+      <div class="main-wapper pb-0">
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-3">
+          <el-card header="Encode">
+            <div class="flex gap-3">
+              <el-form-item label-position="top" label="Algorithm:" class="flex-1">
+                <el-select
+                  v-model="Store.algorithm"
+                  class="w-full"
+                  @change="Store.onAlgorithmChange()"
+                >
+                  <template v-for="item in Store.algorithms" :key="item">
+                    <el-option :value="item" :label="item"></el-option>
+                  </template>
+                </el-select>
+              </el-form-item>
+              <el-form-item label-position="top" label="Secret:" class="flex-1">
+                <el-input v-model="Store.secret" clearable @input="Store.createToken()" />
+              </el-form-item>
+            </div>
+
+            <el-form-item label-position="top" label="Header:">
+              <el-input
+                v-model="Store.header"
+                type="textarea"
+                :rows="5"
+                placeholder="JWT header JSON"
+                @input="Store.createToken()"
+              />
+            </el-form-item>
+
+            <el-form-item label-position="top" label="Payload:">
+              <el-input
+                v-model="Store.payload"
+                type="textarea"
+                :rows="8"
+                placeholder="JWT payload JSON"
+                @input="Store.createToken()"
+              />
+            </el-form-item>
+
+            <el-alert v-if="Store.encodeError" :title="Store.encodeError" type="error" show-icon />
+
+            <el-form-item class="mt-4" label-position="top" label="JWT:">
+              <el-input v-model="Store.token" type="textarea" :rows="5" readonly />
+            </el-form-item>
+
+            <div class="flex justify-center">
+              <el-button @click="Store.useCreatedToken()">Decode This Token</el-button>
+            </div>
+          </el-card>
+
+          <el-card header="Decode">
+            <div class="flex gap-3">
+              <el-form-item label-position="top" label="Algorithm:" class="flex-1">
+                <el-select v-model="Store.decodeAlgorithm" class="w-full" @change="Store.decode()">
+                  <template v-for="item in Store.algorithms" :key="item">
+                    <el-option :value="item" :label="item"></el-option>
+                  </template>
+                </el-select>
+              </el-form-item>
+              <el-form-item label-position="top" label="Secret:" class="flex-1">
+                <el-input v-model="Store.decodeSecret" clearable @input="Store.decode()" />
+              </el-form-item>
+            </div>
+
+            <el-form-item label-position="top" label="JWT:">
+              <el-input
+                v-model="Store.decodedToken"
+                type="textarea"
+                :rows="6"
+                placeholder="Paste JWT here"
+                @input="Store.decode()"
+              />
+            </el-form-item>
+
+            <el-alert v-if="Store.decodeError" :title="Store.decodeError" type="error" show-icon />
+            <el-alert
+              v-else
+              :title="Store.signatureValid ? 'Signature verified' : 'Signature invalid'"
+              :type="Store.signatureValid ? 'success' : 'warning'"
+              show-icon
+            />
+
+            <el-form-item class="mt-4" label-position="top" label="Header:">
+              <el-input v-model="Store.decodedHeader" type="textarea" :rows="5" readonly />
+            </el-form-item>
+
+            <el-form-item label-position="top" label="Payload:">
+              <el-input v-model="Store.decodedPayload" type="textarea" :rows="8" readonly />
+            </el-form-item>
+          </el-card>
+        </div>
+      </div>
+    </el-scrollbar>
+  </div>
+</template>

--- a/src/render/components/Tools/JWT/Module.ts
+++ b/src/render/components/Tools/JWT/Module.ts
@@ -1,0 +1,13 @@
+import { defineAsyncComponent, markRaw } from 'vue'
+import type { AppToolModuleItem } from '@/core/type'
+import { I18nT } from '@lang/index'
+
+const module: AppToolModuleItem = {
+  id: 'jwt-encoder-decoder',
+  type: 'Crypto',
+  label: () => I18nT('tools.jwt-title'),
+  icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18"></path><path d="M5 7l14 10"></path><path d="M19 7L5 17"></path><circle cx="12" cy="12" r="9"></circle></g></svg>',
+  index: 4,
+  component: markRaw(defineAsyncComponent(() => import('./Index.vue')))
+}
+export default module

--- a/src/render/components/Tools/JWT/store.ts
+++ b/src/render/components/Tools/JWT/store.ts
@@ -1,0 +1,167 @@
+import { reactive } from 'vue'
+import { enc, HmacSHA256, HmacSHA384, HmacSHA512 } from 'crypto-js'
+
+type JwtAlgorithm = 'none' | 'HS256' | 'HS384' | 'HS512'
+
+type JwtPart = Record<string, any>
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+const jwtAlgorithms: JwtAlgorithm[] = ['none', 'HS256', 'HS384', 'HS512']
+
+const hmacAlgorithms: Partial<Record<JwtAlgorithm, (value: string, secret: string) => string>> = {
+  HS256: (value, secret) => HmacSHA256(value, secret).toString(enc.Base64),
+  HS384: (value, secret) => HmacSHA384(value, secret).toString(enc.Base64),
+  HS512: (value, secret) => HmacSHA512(value, secret).toString(enc.Base64)
+}
+
+const isSignableAlgorithm = (algorithm: JwtAlgorithm) =>
+  algorithm === 'none' || !!hmacAlgorithms[algorithm]
+
+const isJwtAlgorithm = (value: string): value is JwtAlgorithm => {
+  return jwtAlgorithms.includes(value as JwtAlgorithm)
+}
+
+const base64UrlEncode = (value: string) => {
+  const bytes = encoder.encode(value)
+  let binary = ''
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte)
+  })
+  return btoa(binary).replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+}
+
+const base64UrlDecode = (value: string) => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=')
+  const binary = atob(padded)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+  return decoder.decode(bytes)
+}
+
+const parseJson = (value: string): JwtPart => {
+  const data = JSON.parse(value)
+  if (!data || Array.isArray(data) || typeof data !== 'object') {
+    throw new Error('Invalid JSON object')
+  }
+  return data
+}
+
+const formatJson = (value: JwtPart) => JSON.stringify(value, null, 2)
+
+const normalizeHeader = (header: JwtPart, algorithm: JwtAlgorithm) => {
+  return {
+    ...header,
+    alg: algorithm,
+    typ: header.typ || 'JWT'
+  }
+}
+
+const sign = (header: string, payload: string, secret: string, algorithm: JwtAlgorithm) => {
+  const encodedHeader = base64UrlEncode(header)
+  const encodedPayload = base64UrlEncode(payload)
+  if (algorithm === 'none') {
+    return `${encodedHeader}.${encodedPayload}.`
+  }
+  const signer = hmacAlgorithms[algorithm]
+  if (!signer) {
+    throw new Error(`${algorithm} signing is not supported locally`)
+  }
+  const signature = signer(`${encodedHeader}.${encodedPayload}`, secret)
+  return `${encodedHeader}.${encodedPayload}.${signature.replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')}`
+}
+
+const defaultHeader = formatJson({
+  alg: 'HS256',
+  typ: 'JWT'
+})
+
+const defaultPayload = formatJson({
+  sub: '1234567890',
+  name: 'FlyEnv',
+  iat: 1516239022
+})
+
+const defaultSecret = 'your-256-bit-secret'
+
+const store = reactive({
+  algorithms: jwtAlgorithms,
+  algorithm: 'HS256' as JwtAlgorithm,
+  secret: defaultSecret,
+  header: defaultHeader,
+  payload: defaultPayload,
+  token: '',
+  decodedToken: '',
+  decodedHeader: '',
+  decodedPayload: '',
+  decodeSecret: defaultSecret,
+  decodeAlgorithm: 'HS256' as JwtAlgorithm,
+  encodeError: '',
+  decodeError: '',
+  signatureValid: false,
+  isSignableAlgorithm,
+  onAlgorithmChange() {
+    this.encodeError = ''
+    try {
+      const header = normalizeHeader(parseJson(this.header), this.algorithm)
+      this.header = formatJson(header)
+      this.createToken()
+    } catch (error: any) {
+      this.encodeError = error?.message ?? 'Invalid JSON'
+    }
+  },
+  createToken() {
+    this.encodeError = ''
+    try {
+      if (!isSignableAlgorithm(this.algorithm)) {
+        throw new Error(`${this.algorithm} signing is not supported locally`)
+      }
+      const header = normalizeHeader(parseJson(this.header), this.algorithm)
+      parseJson(this.payload)
+      this.token = sign(formatJson(header), this.payload, this.secret, this.algorithm)
+    } catch (error: any) {
+      this.encodeError = error?.message ?? 'Invalid JSON'
+    }
+  },
+  decode() {
+    this.decodeError = ''
+    this.signatureValid = false
+    try {
+      const parts = this.decodedToken.trim().split('.')
+      if (parts.length !== 3) {
+        throw new Error('JWT must contain header, payload and signature')
+      }
+      const header = base64UrlDecode(parts[0])
+      const payload = base64UrlDecode(parts[1])
+      const headerJson = parseJson(header)
+      const payloadJson = parseJson(payload)
+      this.decodedHeader = formatJson(headerJson)
+      this.decodedPayload = formatJson(payloadJson)
+      const tokenAlgorithm = String(headerJson.alg || this.decodeAlgorithm)
+      if (!isJwtAlgorithm(tokenAlgorithm)) {
+        throw new Error(`${String(headerJson.alg)} is not supported`)
+      }
+      this.decodeAlgorithm = tokenAlgorithm
+      if (!isSignableAlgorithm(this.decodeAlgorithm)) {
+        throw new Error(`${this.decodeAlgorithm} verification is not supported locally`)
+      }
+      const expected = sign(header, payload, this.decodeSecret, this.decodeAlgorithm).split('.')[2]
+      this.signatureValid = expected === parts[2]
+    } catch (error: any) {
+      this.decodeError = error?.message ?? 'Invalid JWT'
+      this.decodedHeader = ''
+      this.decodedPayload = ''
+    }
+  },
+  useCreatedToken() {
+    this.decodedToken = this.token
+    this.decodeSecret = this.secret
+    this.decode()
+  }
+})
+
+store.createToken()
+store.useCreatedToken()
+
+export default store


### PR DESCRIPTION
- Added a JWT tool entry page, supporting JWT encoding and decoding functions

- Supports selecting encryption algorithms none, HS256, HS384, and HS512

- Implements JSON input and formatted display for JWT headers and payloads

<img width="1785" height="954" alt="tools-jwt" src="https://github.com/user-attachments/assets/75f6cb77-1425-44a2-a3c6-005179291bf4" />


