### PR TITLE
Fix Hermes TUI shortcut command

### DIFF
--- a/src/render/components/Hermes/command.json
+++ b/src/render/components/Hermes/command.json
@@ -130,7 +130,7 @@
       "nameKey": "hermes.category.dashboardTui",
       "commands": [
         { "label": "hermes dashboard", "descriptionKey": "hermes.cmd.dashboard", "needInput": false },
-        { "label": "hermes tui", "descriptionKey": "hermes.cmd.tui", "needInput": false }
+        { "label": "hermes --tui", "descriptionKey": "hermes.cmd.tui", "needInput": false }
       ]
     },
     {


### PR DESCRIPTION
This PR fixes the Hermes TUI shortcut command.

The current shortcut runs:

`hermes tui`

But `tui` is not a valid Hermes subcommand. The correct command is:

`hermes --tui`

I tested this locally on macOS. `hermes tui` returns:

`hermes: error: argument command: invalid choice: 'tui'`

After this change, the FlyEnv shortcut should launch Hermes TUI correctly.