### PR TITLE
Fix: serviceStartExec null crash, EnvSync.clean() incomplete reset, RabbitMQ dead code

### DIFF
--- a/src/fork/module/RabbitMQ/index.ts
+++ b/src/fork/module/RabbitMQ/index.ts
@@ -371,7 +371,6 @@ PLUGINS_DIR="${pathFixedToUnix(pluginsDir)}"`
             })
             return Promise.all(all)
           }
-          return Promise.resolve([])
         })
         .then((list) => {
           list.forEach((v, i) => {

--- a/src/fork/util/ServiceStart.ts
+++ b/src/fork/util/ServiceStart.ts
@@ -171,6 +171,24 @@ export async function serviceStartExec(
   })
 
   if (!checkPidFile) {
+    if (!res) {
+      let msg = 'Start Fail'
+      if (existsSync(errFile)) {
+        msg = await readFile(errFile, 'utf-8')
+      } else if (error) {
+        msg = error && error?.toString ? error?.toString() : ''
+      }
+      on({
+        'APP-On-Log': AppLog(
+          'error',
+          I18nT('appLog.startServiceFail', {
+            error: msg,
+            service: `${version.typeFlag}-${version.version}`
+          })
+        )
+      })
+      throw new Error(msg)
+    }
     let pid = ''
     const stdout = res.stdout.trim() + '\n' + res.stderr.trim()
     const regex = /FlyEnv-Process-ID(.*?)FlyEnv-Process-ID/g

--- a/src/shared/EnvSync.ts
+++ b/src/shared/EnvSync.ts
@@ -285,6 +285,7 @@ class EnvSync {
     this.AppEnv = undefined
     this.CMDPath = undefined
     this.PowerShellPath = undefined
+    this.SystemPath = undefined
   }
 }
 


### PR DESCRIPTION
## Summary

- **Bug 1 (Critical)**: `serviceStartExec` crashes with `TypeError: Cannot read properties of undefined` when `checkPidFile: false` and the shell process fails to start. `res` is `undefined` in the error path but `res.stdout.trim()` is accessed unconditionally. Affects 11+ modules: MailPit, Qdrant, ETCD, Typesense, Minio, RabbitMQ, N8N, Memcached, Numa, MeiliSearch, Tomcat.

- **Bug 2 (Medium)**: `EnvSync.clean()` resets `AppEnv`, `CMDPath`, `PowerShellPath` but forgets `SystemPath`. The 5-minute cache refresh timer leaves a stale `SystemPath` that gets reused in the next `sync()` call's PATH construction.

- **Bug 3 (Minor)**: `RabbitMQ.allInstalledVersions` has unreachable `return Promise.resolve([])` after an if/else where both branches already return.

## Changes

| File | Change |
|------|--------|
| `src/fork/util/ServiceStart.ts` | Guard `!res` before accessing `res.stdout`; read error from `errFile` or caught exception and throw with proper log |
| `src/shared/EnvSync.ts` | Add `this.SystemPath = undefined` to `clean()` |
| `src/fork/module/RabbitMQ/index.ts` | Remove unreachable `return Promise.resolve([])` |

## Test plan

- [ ] Start a service that uses `checkPidFile: false` (e.g. MailPit, Qdrant) with an invalid binary path — should now show a proper error message instead of crashing
- [ ] Verify `EnvSync.clean()` clears all cached fields on Windows
- [ ] Verify RabbitMQ version detection still works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)