### PR TITLE
Enhance Laravel project creation and update version handling

### DIFF
--- a/src/fork/module/Project/index.ts
+++ b/src/fork/module/Project/index.ts
@@ -12,7 +12,7 @@ class Manager extends Base {
 
   handleProjectDir(dir: string, framework: string) {
     return new ForkPromise(async (resolve, reject) => {
-      const pdir = join(dir, 'flyenv-create-project')
+      const pdir = join(dir, 'flyenv-created-project')
       if (!existsSync(pdir)) {
         return reject(new Error(I18nT('appLog.newProjectFail')))
       }

--- a/src/render/components/Host/CreateProject/phpCreate.vue
+++ b/src/render/components/Host/CreateProject/phpCreate.vue
@@ -37,17 +37,43 @@
             </div>
             <div class="park">
               <div class="title">
+                <span>{{ I18nT('host.frameworkVersion') }}</span>
+              </div>
+              <el-select
+                v-model="ProjectSetup.form.PHP.version"
+                class="w-56 max-w-56"
+                filterable
+                :disabled="loading || created"
+              >
+                <template v-for="(v, _k) in app.list" :key="_k">
+                  <el-option :value="v.version" :label="getLabel(v)"></el-option>
+                </template>
+              </el-select>
+            </div>
+            <div class="park">
+              <div class="title">
+                <span>{{ I18nT('host.projectName') }}</span>
+              </div>
+              <el-input
+                v-model="ProjectSetup.form.PHP.name"
+                class="w-56 max-w-56"
+                placeholder="example-app"
+                :disabled="loading || created"
+              />
+            </div>
+            <div class="park">
+              <div class="title">
                 <span>{{ I18nT('base.phpVersion') }}</span>
               </div>
               <el-select
                 v-model="ProjectSetup.form.PHP.php"
                 class="w-56 max-w-56"
                 filterable
-                :disabled="loading || created"
+                :disabled="loading || created || !ProjectSetup.form.PHP.version"
               >
                 <el-option value="" :label="I18nT('host.useSysVersion')"></el-option>
                 <template v-for="(v, _k) in phpVersions" :key="_k">
-                  <el-option :value="v.bin" :label="`${v.version}-${v.bin}`"></el-option>
+                  <el-option :value="v.bin" :label="`${v.version}-${v.bin}`" :disabled="isPhpVersionDisabled(v.version)"></el-option>
                 </template>
               </el-select>
             </div>
@@ -64,21 +90,6 @@
                 <el-option value="" :label="I18nT('host.useSysVersion')"></el-option>
                 <template v-for="(v, _k) in composerVersions" :key="_k">
                   <el-option :value="v.bin" :label="`${v.version}-${v.bin}`"></el-option>
-                </template>
-              </el-select>
-            </div>
-            <div class="park">
-              <div class="title">
-                <span>{{ I18nT('host.frameworkVersion') }}</span>
-              </div>
-              <el-select
-                v-model="ProjectSetup.form.PHP.version"
-                class="w-56 max-w-56"
-                filterable
-                :disabled="loading || created"
-              >
-                <template v-for="(v, _k) in app.list" :key="_k">
-                  <el-option :value="v.version" :label="v.name"></el-option>
                 </template>
               </el-select>
             </div>
@@ -109,14 +120,15 @@
   </el-dialog>
 </template>
 <script lang="ts" setup>
-  import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+  import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
   import { AsyncComponentSetup } from '@/util/AsyncComponent'
   import { I18nT } from '@lang/index'
   import { BrewStore } from '@/store/brew'
+  import { compareVersions } from '@shared/compare-versions'
   import AppVersions from './version'
   import { ProjectSetup } from '@/components/Host/CreateProject/project'
   import XTerm from '@/util/XTerm'
-  import { join } from '@/util/path-browserify'
+  import { join, dirname } from '@/util/path-browserify'
   import { dialog, fs } from '@/util/NodeFn'
 
   const { show, onClosed, onSubmit, closedFn, callback } = AsyncComponentSetup()
@@ -124,6 +136,8 @@
   const props = defineProps<{
     type: keyof typeof AppVersions
   }>()
+
+  ProjectSetup.form.PHP.name = props.type.toLowerCase()
 
   const xterm = ref<HTMLElement>()
 
@@ -151,7 +165,53 @@
   })
 
   const createAble = computed(() => {
-    return !!ProjectSetup.form.PHP.dir && !!ProjectSetup.form.PHP.version
+    return (
+      !!ProjectSetup.form.PHP.dir &&
+      !!ProjectSetup.form.PHP.version &&
+      !!ProjectSetup.form.PHP.name.trim()
+    )
+  })
+
+  const getLabel = (v: any) => {
+    return v.php ? `${v.name} (${v.php})` : v.name
+  }
+
+  const isLaravel8OrAbove = (version?: string) => {
+    if (!version) return false
+    if (version === '*') return true
+    const major = parseInt(version.split('.')[0])
+    return !isNaN(major) && major >= 8
+  }
+
+  const getMinPhpVersion = (phpConstraint?: string) => {
+    if (!phpConstraint) return null
+    return phpConstraint.replace(/[^\d.]/g, '')
+  }
+
+  const isPhpVersionDisabled = (phpVersion: string) => {
+    const currentFrameworkVersion = ProjectSetup.form.PHP.version
+    if (!currentFrameworkVersion) return false
+
+    const currentFramework = app.value.list.find((f: any) => f.version === currentFrameworkVersion)
+    if (!currentFramework || !currentFramework.php) return false
+
+    const minPhp = getMinPhpVersion(currentFramework.php)
+    if (!minPhp) return false
+
+    try {
+      return compareVersions(phpVersion, minPhp) < 0
+    } catch (e) {
+      return false
+    }
+  }
+
+  watch(() => ProjectSetup.form.PHP.version, () => {
+    if (ProjectSetup.form.PHP.php) {
+      const selectedVersionObj = phpVersions.value.find(p => p.bin === ProjectSetup.form.PHP.php)
+      if (selectedVersionObj && isPhpVersionDisabled(selectedVersionObj.version)) {
+        ProjectSetup.form.PHP.php = ''
+      }
+    }
   })
 
   const phpVersions = computed(() => {
@@ -201,8 +261,7 @@
         command.push(`export ${k}="${v}"`)
       }
     }
-    command.push(`cd "${form.dir}"`)
-
+    const projectDir = join(form.dir, form.name)
     if (props.type === 'WordPress') {
       const tmpl = `{
   "require": {
@@ -215,8 +274,10 @@
   }
 }
 `
-      await fs.writeFile(join(form.dir, 'composer.json'), tmpl)
+      await fs.mkdirp(projectDir)
+      await fs.writeFile(join(projectDir, 'composer.json'), tmpl)
 
+      command.push(`cd "${projectDir}"`)
       if (form.php && form.composer) {
         command.push(`export PATH="${form.php}:$PATH"`)
         command.push(`"${form.php}" "${form.composer}" self-update`)
@@ -232,7 +293,26 @@
         command.push(`composer self-update`)
         command.push(`composer update`)
       }
+    } else if (props.type === 'Laravel' && form.version === '*') {
+      command.push(`cd "${form.dir}"`)
+      if (form.php) {
+        command.push(`export PATH="${dirname(form.php)}:$PATH"`)
+      }
+      let composerCmd = 'composer'
+      if (form.php && form.composer) {
+        composerCmd = `"${form.php}" "${form.composer}"`
+      } else if (form.composer) {
+        composerCmd = `php "${form.composer}"`
+      }
+      command.push(`${composerCmd} global require laravel/installer`)
+      command.push(
+        `export COMPOSER_BIN=$(${composerCmd} global config bin-dir --absolute 2>/dev/null || echo "$HOME/.composer/vendor/bin")`
+      )
+      command.push(`export PATH="$COMPOSER_BIN:$PATH"`)
+      command.push(`laravel new "${form.name}" --no-interaction`)
     } else {
+      await fs.mkdirp(projectDir)
+      command.push(`cd "${projectDir}"`)
       const name = app.value.package
       if (form.php && form.composer) {
         command.push(`export PATH="${form.php}:$PATH"`)
@@ -297,7 +377,7 @@
     let dir = ProjectSetup.form.PHP.dir
     let nginxRewrite = ''
     if (framework.includes('wordpress')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'wordpress')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'wordpress')
       nginxRewrite = `location /
 {
 \t try_files $uri $uri/ /index.php?$args;
@@ -305,39 +385,39 @@
 
 rewrite /wp-admin$ $scheme://$host$uri/ permanent;`
     } else if (framework.includes('laravel')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
 \ttry_files $uri $uri/ /index.php$is_args$query_string;
 }`
     } else if (framework.includes('yii2')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'web')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'web')
       nginxRewrite = `location / {
     try_files $uri $uri/ /index.php?$args;
 }`
     } else if (framework.includes('thinkphp')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
 \tif (!-e $request_filename){
 \t\trewrite  ^(.*)$  /index.php?s=$1  last;   break;
 \t}
 }`
     } else if (framework.includes('symfony')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri /index.php$is_args$args;
 }`
     } else if (framework.includes('cakephp')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'webroot')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'webroot')
       nginxRewrite = `location / {
     try_files $uri $uri/ /index.php?$args;
 }`
     } else if (framework.includes('slim')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri /index.php$is_args$args;
 }`
     } else if (framework.includes('codeIgniter')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri $uri/ /index.php$is_args$args;
 }`

--- a/src/render/components/Host/CreateProject/phpCreate.win.vue
+++ b/src/render/components/Host/CreateProject/phpCreate.win.vue
@@ -37,17 +37,43 @@
             </div>
             <div class="park">
               <div class="title">
+                <span>{{ I18nT('host.frameworkVersion') }}</span>
+              </div>
+              <el-select
+                v-model="ProjectSetup.form.PHP.version"
+                class="w-56 max-w-56"
+                filterable
+                :disabled="loading || created"
+              >
+                <template v-for="(v, _k) in app.list" :key="_k">
+                  <el-option :value="v.version" :label="getLabel(v)"></el-option>
+                </template>
+              </el-select>
+            </div>
+            <div class="park">
+              <div class="title">
+                <span>{{ I18nT('host.projectName') }}</span>
+              </div>
+              <el-input
+                v-model="ProjectSetup.form.PHP.name"
+                class="w-56 max-w-56"
+                placeholder="example-app"
+                :disabled="loading || created"
+              />
+            </div>
+            <div class="park">
+              <div class="title">
                 <span>{{ I18nT('base.phpVersion') }}</span>
               </div>
               <el-select
                 v-model="ProjectSetup.form.PHP.php"
                 class="w-56 max-w-56"
                 filterable
-                :disabled="loading || created"
+                :disabled="loading || created || !ProjectSetup.form.PHP.version"
               >
                 <el-option value="" :label="I18nT('host.useSysVersion')"></el-option>
                 <template v-for="(v, _k) in phpVersions" :key="_k">
-                  <el-option :value="v.bin" :label="`${v.version}-${v.bin}`"></el-option>
+                  <el-option :value="v.bin" :label="`${v.version}-${v.bin}`" :disabled="isPhpVersionDisabled(v.version)"></el-option>
                 </template>
               </el-select>
             </div>
@@ -64,21 +90,6 @@
                 <el-option value="" :label="I18nT('host.useSysVersion')"></el-option>
                 <template v-for="(v, _k) in composerVersions" :key="_k">
                   <el-option :value="v.bin" :label="`${v.version}-${v.bin}`"></el-option>
-                </template>
-              </el-select>
-            </div>
-            <div class="park">
-              <div class="title">
-                <span>{{ I18nT('host.frameworkVersion') }}</span>
-              </div>
-              <el-select
-                v-model="ProjectSetup.form.PHP.version"
-                class="w-56 max-w-56"
-                filterable
-                :disabled="loading || created"
-              >
-                <template v-for="(v, _k) in app.list" :key="_k">
-                  <el-option :value="v.version" :label="v.name"></el-option>
                 </template>
               </el-select>
             </div>
@@ -114,10 +125,11 @@
   </el-dialog>
 </template>
 <script lang="ts" setup>
-  import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+  import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
   import { AsyncComponentSetup } from '@/util/AsyncComponent'
   import { I18nT } from '@lang/index'
   import { BrewStore } from '@/store/brew'
+  import { compareVersions } from '@shared/compare-versions'
   import AppVersions from './version'
   import { ProjectSetup } from '@/components/Host/CreateProject/project'
   import XTerm from '@/util/XTerm'
@@ -131,6 +143,8 @@
   const props = defineProps<{
     type: keyof typeof AppVersions
   }>()
+
+  ProjectSetup.form.PHP.name = props.type.toLowerCase()
 
   const xterm = ref<HTMLElement>()
 
@@ -167,7 +181,53 @@
   })
 
   const createAble = computed(() => {
-    return !!ProjectSetup.form.PHP.dir && !!ProjectSetup.form.PHP.version
+    return (
+      !!ProjectSetup.form.PHP.dir &&
+      !!ProjectSetup.form.PHP.version &&
+      !!ProjectSetup.form.PHP.name.trim()
+    )
+  })
+
+  const getLabel = (v: any) => {
+    return v.php ? `${v.name} (${v.php})` : v.name
+  }
+
+  const isLaravel8OrAbove = (version?: string) => {
+    if (!version) return false
+    if (version === '*') return true
+    const major = parseInt(version.split('.')[0])
+    return !isNaN(major) && major >= 8
+  }
+
+  const getMinPhpVersion = (phpConstraint?: string) => {
+    if (!phpConstraint) return null
+    return phpConstraint.replace(/[^\d.]/g, '')
+  }
+
+  const isPhpVersionDisabled = (phpVersion: string) => {
+    const currentFrameworkVersion = ProjectSetup.form.PHP.version
+    if (!currentFrameworkVersion) return false
+
+    const currentFramework = app.value.list.find((f: any) => f.version === currentFrameworkVersion)
+    if (!currentFramework || !currentFramework.php) return false
+
+    const minPhp = getMinPhpVersion(currentFramework.php)
+    if (!minPhp) return false
+
+    try {
+      return compareVersions(phpVersion, minPhp) < 0
+    } catch (e) {
+      return false
+    }
+  }
+
+  watch(() => ProjectSetup.form.PHP.version, () => {
+    if (ProjectSetup.form.PHP.php) {
+      const selectedVersionObj = phpVersions.value.find(p => p.bin === ProjectSetup.form.PHP.php)
+      if (selectedVersionObj && isPhpVersionDisabled(selectedVersionObj.version)) {
+        ProjectSetup.form.PHP.php = ''
+      }
+    }
   })
 
   const phpVersions = computed(() => {
@@ -217,8 +277,7 @@
         command.push(`$env:${k}="${v}"`)
       }
     }
-    command.push(`cd "${form.dir}"`)
-
+    const projectDir = join(form.dir, form.name)
     if (props.type === 'WordPress') {
       const tmpl = `{
   "require": {
@@ -231,8 +290,10 @@
   }
 }
 `
-      await fs.writeFile(join(form.dir, 'composer.json'), tmpl)
+      await fs.mkdirp(projectDir)
+      await fs.writeFile(join(projectDir, 'composer.json'), tmpl)
 
+      command.push(`cd "${projectDir}"`)
       if (form.php && form.composer) {
         command.push(`$env:PATH = "${dirname(form.php)};" + $env:PATH`)
         command.push(`php "${form.composer}" update`)
@@ -244,25 +305,41 @@
       } else {
         command.push(`composer update`)
       }
+    } else if (props.type === 'Laravel' && form.version === '*') {
+      command.push(`cd "${form.dir}"`)
+      if (form.php) {
+        command.push(`$env:PATH = "${dirname(form.php)};" + $env:PATH`)
+      }
+      let composerCmd = 'composer'
+      if (form.composer) {
+        composerCmd = `php "${form.composer}"`
+      }
+      command.push(`${composerCmd} global require laravel/installer`)
+      command.push(
+        `$composer_bin = & ${composerCmd} global config bin-dir --absolute; if (-not $composer_bin) { $composer_bin = "$env:APPDATA\\Composer\\vendor\\bin" }; $env:PATH = "$composer_bin;" + $env:PATH`
+      )
+      command.push(`laravel new "${form.name}" --no-interaction`)
     } else {
+      await fs.mkdirp(projectDir)
+      command.push(`cd "${projectDir}"`)
       const name = app.value.package
       if (form.php && form.composer) {
         command.push(`$env:PATH = "${dirname(form.php)};" + $env:PATH`)
         command.push(
-          `php "${form.composer}" create-project --prefer-dist "${name}" "flyenv-create-project" "${form.version}"`
+          `php "${form.composer}" create-project --prefer-dist "${name}" "flyenv-created-project" "${form.version}"`
         )
       } else if (form.php) {
         command.push(`$env:PATH = "${dirname(form.php)};" + $env:PATH`)
         command.push(
-          `composer create-project --prefer-dist "${name}" "flyenv-create-project" "${form.version}"`
+          `composer create-project --prefer-dist "${name}" "flyenv-created-project" "${form.version}"`
         )
       } else if (form.composer) {
         command.push(
-          `php "${form.composer}" create-project --prefer-dist "${name}" "flyenv-create-project" "${form.version}"`
+          `php "${form.composer}" create-project --prefer-dist "${name}" "flyenv-created-project" "${form.version}"`
         )
       } else {
         command.push(
-          `composer create-project --prefer-dist "${name}" "flyenv-create-project" "${form.version}"`
+          `composer create-project --prefer-dist "${name}" "flyenv-created-project" "${form.version}"`
         )
       }
     }
@@ -270,13 +347,13 @@
     nextTick().then(() => {
       execXTerm.mount(xterm.value!).then(() => {
         execXTerm?.send(command, false)?.then(() => {
-          if (props.type === 'WordPress') {
+          if (props.type === 'WordPress' || (props.type === 'Laravel' && form.version === '*')) {
             created.value = true
           } else {
             IPC.send(
               'app-fork:project',
               'handleProjectDir',
-              ProjectSetup.form.PHP.dir,
+              projectDir,
               props.type.toLowerCase()
             ).then((key: string, res: any) => {
               IPC.off(key)
@@ -321,7 +398,7 @@
     let dir = ProjectSetup.form.PHP.dir
     let nginxRewrite = ''
     if (framework.includes('wordpress')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'wordpress')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'wordpress')
       nginxRewrite = `location /
 {
 \t try_files $uri $uri/ /index.php?$args;
@@ -329,39 +406,39 @@
 
 rewrite /wp-admin$ $scheme://$host$uri/ permanent;`
     } else if (framework.includes('laravel')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
 \ttry_files $uri $uri/ /index.php$is_args$query_string;
 }`
     } else if (framework.includes('yii2')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'web')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'web')
       nginxRewrite = `location / {
     try_files $uri $uri/ /index.php?$args;
 }`
     } else if (framework.includes('thinkphp')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
 \tif (!-e $request_filename){
 \t\trewrite  ^(.*)$  /index.php?s=$1  last;   break;
 \t}
 }`
     } else if (framework.includes('symfony')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri /index.php$is_args$args;
 }`
     } else if (framework.includes('cakephp')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'webroot')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'webroot')
       nginxRewrite = `location / {
     try_files $uri $uri/ /index.php?$args;
 }`
     } else if (framework.includes('slim')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri /index.php$is_args$args;
 }`
     } else if (framework.includes('codeIgniter')) {
-      dir = join(ProjectSetup.form.PHP.dir, 'public')
+      dir = join(ProjectSetup.form.PHP.dir, ProjectSetup.form.PHP.name, 'public')
       nginxRewrite = `location / {
         try_files $uri $uri/ /index.php$is_args$args;
 }`

--- a/src/render/components/Host/CreateProject/project.ts
+++ b/src/render/components/Host/CreateProject/project.ts
@@ -5,6 +5,7 @@ export type ProjectTypes = 'PHP' | 'NodeJS' | 'Python' | 'Go'
 
 export type ProjectPHPForm = {
   dir: string
+  name: string
   php: string
   composer: string
   version: string | undefined
@@ -54,6 +55,7 @@ export const ProjectSetup = reactive<{
   form: {
     PHP: {
       dir: '',
+      name: 'flyenv-created-project',
       php: '',
       composer: '',
       version: undefined,
@@ -88,6 +90,7 @@ export const ProjectSetup = reactive<{
   },
   phpFormInit() {
     this.form.PHP.dir = ''
+    this.form.PHP.name = 'flyenv-created-project'
     this.form.PHP.php = ''
     this.form.PHP.composer = ''
     this.form.PHP.version = undefined

--- a/src/render/components/Host/CreateProject/version.ts
+++ b/src/render/components/Host/CreateProject/version.ts
@@ -31,39 +31,48 @@ const version = {
       },
       {
         name: 'laravel 13',
-        version: '13.*'
+        version: '13.*',
+        php: '^8.3'
       },
       {
         name: 'laravel 12',
-        version: '12.*'
+        version: '12.*',
+        php: '^8.2'
       },
       {
         name: 'laravel 11',
-        version: '11.*'
+        version: '11.*',
+        php: '^8.2'
       },
       {
         name: 'laravel 10',
-        version: '10.*'
+        version: '10.*',
+        php: '^8.1'
       },
       {
         name: 'laravel 9',
-        version: '9.*'
+        version: '9.*',
+        php: '^8.0'
       },
       {
         name: 'laravel 8',
-        version: '8.*'
+        version: '8.*',
+        php: '^7.3'
       },
       {
         name: 'laravel 7',
-        version: '7.*'
+        version: '7.*',
+        php: '^7.2.5'
       },
       {
         name: 'laravel 6',
-        version: '6.*'
+        version: '6.*',
+        php: '^7.2'
       },
       {
         name: 'laravel 5',
-        version: '5.8.*'
+        version: '5.8.*',
+        php: '^7.1.3'
       }
     ]
   },

--- a/src/render/components/Host/CreateProject/version.ts
+++ b/src/render/components/Host/CreateProject/version.ts
@@ -30,6 +30,10 @@ const version = {
         version: '*'
       },
       {
+        name: 'laravel 13',
+        version: '13.*'
+      },
+      {
         name: 'laravel 12',
         version: '12.*'
       },


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the PHP project creation flow in both the main and Windows-specific Vue components. The main goals are to support custom project directory names, improve PHP version compatibility handling, and enhance the user interface for project creation. Below are the most important changes:

**Project Directory and Naming Enhancements**
- Added a `projectName` field to the project creation UI, allowing users to specify a custom directory name for new projects. All logic for file creation and command execution now uses this name, ensuring each project is created in its own directory. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bR140-R141) [[2]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL204-R264) [[3]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL218-R280) [[4]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL300-R420) [[5]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fR147-R148) [[6]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL220-R280) [[7]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL234-R296) [[8]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fR308-R356)

**Framework and PHP Version Compatibility**
- Improved PHP version selection: The UI now disables incompatible PHP versions based on the selected framework version's requirements. This prevents users from selecting a PHP version that doesn't meet the framework's minimum requirement. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL154-R214) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL170-R230)
- Automatically resets the selected PHP version if it becomes incompatible when the framework version changes. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL154-R214) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL170-R230)

**User Interface Improvements**
- Refactored the order and labels of the form fields for clarity (e.g., "Framework Version" and "Project Name" now appear before PHP and Composer version selection). [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL40-R92) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL40-R92)
- The "Create" button is now only enabled when all required fields (directory, framework version, project name) are filled. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL154-R214) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL170-R230)

**Command and File Generation Logic**
- For Laravel projects with the latest version (`*`), added logic to use the global Laravel installer instead of `composer create-project`, improving compatibility with Laravel's recommended installation method. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bR296-R315) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fR308-R356)
- Updated all file and directory operations to respect the new project name, ensuring that configuration files and web roots are placed in the correct locations. [[1]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL204-R264) [[2]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL218-R280) [[3]](diffhunk://#diff-d15f655c0235537dcfe6824d7dfe4292167195662e89e08306de61b2a03d010bL300-R420) [[4]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL220-R280) [[5]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fL234-R296) [[6]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fR308-R356)

**Bug Fixes and Refactoring**
- Fixed a typo in the directory name from `flyenv-create-project` to `flyenv-created-project` for consistency. [[1]](diffhunk://#diff-780ccedbb03de4cf636ba0998e4483e7433040f64e907564375905e9055dcba9L15-R15) [[2]](diffhunk://#diff-5817cf1e733c3c368bcac9e321447553f9bccd5f8111aacc9e4ce5495edebe3fR308-R356)

These changes collectively provide a more robust and user-friendly experience for creating PHP projects, with better validation and compatibility handling.