### PR TITLE
fix(podman,n8n): support compose v2 and dashboard URL config

### DIFF
--- a/src/fork/module/Podman/index.ts
+++ b/src/fork/module/Podman/index.ts
@@ -14,6 +14,16 @@ class Podman extends Base {
     this.type = 'podman'
   }
 
+  private async getComposeCommand(): Promise<string> {
+    try {
+      await execPromiseWithEnv('docker-compose --version')
+      return 'docker-compose'
+    } catch {}
+
+    await execPromiseWithEnv('docker compose version')
+    return 'docker compose'
+  }
+
   podmanInit() {
     return new ForkPromise(async (resolve) => {
       let version = ''
@@ -440,16 +450,16 @@ class Podman extends Base {
 
   composeStart(paths: string[], projectName: string, socket?: string) {
     return new ForkPromise(async (resolve, reject) => {
-      const arr: string[] = ['docker-compose', ...paths.map((p) => `-f "${p}"`)]
-      if (projectName) {
-        arr.push(`-p ${projectName}`)
-      }
-      arr.push('up -d')
       const env: any = {}
       if (!isWindows() && socket) {
         env.DOCKER_HOST = `unix://${socket}`
       }
       try {
+        const arr: string[] = [await this.getComposeCommand(), ...paths.map((p) => `-f "${p}"`)]
+        if (projectName) {
+          arr.push(`-p ${projectName}`)
+        }
+        arr.push('up -d')
         await execPromiseWithEnv(arr.join(' '), { env })
         resolve(true)
       } catch (e: any) {
@@ -460,16 +470,16 @@ class Podman extends Base {
 
   composeStop(paths: string[], projectName: string, socket?: string) {
     return new ForkPromise(async (resolve, reject) => {
-      const arr: string[] = ['docker-compose', ...paths.map((p) => `-f "${p}"`)]
-      if (projectName) {
-        arr.push(`-p ${projectName}`)
-      }
-      arr.push('down')
       const env: any = {}
       if (!isWindows() && socket) {
         env.DOCKER_HOST = `unix://${socket}`
       }
       try {
+        const arr: string[] = [await this.getComposeCommand(), ...paths.map((p) => `-f "${p}"`)]
+        if (projectName) {
+          arr.push(`-p ${projectName}`)
+        }
+        arr.push('down')
         await execPromiseWithEnv(arr.join(' '), { env })
         resolve(true)
       } catch (e: any) {
@@ -481,8 +491,7 @@ class Podman extends Base {
   checkIsComposeExists() {
     return new ForkPromise(async (resolve, reject) => {
       try {
-        const command = 'docker-compose --version'
-        await execPromiseWithEnv(command)
+        await this.getComposeCommand()
         resolve(true)
       } catch (err: any) {
         reject(err?.message ?? 'fail')
@@ -494,17 +503,17 @@ class Podman extends Base {
   isComposeRunning(paths: string[], projectName: string, socket?: string) {
     return new ForkPromise(async (resolve, reject) => {
       const tmp = join(tmpdir(), `${uuid()}.txt`)
-      const list: string[] = ['docker-compose', ...paths.map((p) => `-f "${p}"`)]
-      if (projectName) {
-        list.push(`-p ${projectName}`)
-      }
-      list.push('ps --format json')
       const env: any = {}
       if (!isWindows() && socket) {
         env.DOCKER_HOST = `unix://${socket}`
       }
       console.log('isComposeRunning env: ', { env })
       try {
+        const list: string[] = [await this.getComposeCommand(), ...paths.map((p) => `-f "${p}"`)]
+        if (projectName) {
+          list.push(`-p ${projectName}`)
+        }
+        list.push('ps --format json')
         await execPromiseWithEnv(`${list.join(' ')} > "${tmp}" ${getRedirect()}`, { env })
         const content = await readFile(tmp, 'utf-8')
         const arr = content.split('\n').filter((f) => {

--- a/src/render/components/N8N/Index.vue
+++ b/src/render/components/N8N/Index.vue
@@ -54,17 +54,36 @@
     return !!current
   })
 
+  const parseEnvValue = (content: string, key: string) => {
+    const match = content
+      .split(/\r?\n/)
+      .find((line: string) => line.trim().startsWith(`${key}=`))
+    const raw = match?.trim().split('=').slice(1).join('=').trim()
+    return raw?.replace(/^['"]|['"]$/g, '')
+  }
+
+  const normalizeUrlPath = (value?: string) => {
+    if (!value) return '/'
+    return value.startsWith('/') ? value : `/${value}`
+  }
+
   const openDashboard = async () => {
+    let protocol = 'http'
+    let host = '127.0.0.1'
     let port = '5678'
+    let path = '/'
     try {
       const envFile = join(window.Server.BaseDir!, 'n8n/n8n.env')
       const content = await fs.readFile(envFile)
-      const match = (content as string)
-        .split('\n')
-        .find((l: string) => l.trim().startsWith('N8N_PORT='))
-      if (match) port = match.trim().split('=')[1]?.trim() || '5678'
+      protocol = parseEnvValue(content as string, 'N8N_PROTOCOL') || protocol
+      host = parseEnvValue(content as string, 'N8N_HOST') || host
+      port = parseEnvValue(content as string, 'N8N_PORT') || port
+      path = normalizeUrlPath(parseEnvValue(content as string, 'N8N_PATH') || path)
     } catch {}
-    shell.openExternal(`http://127.0.0.1:${port}`).catch()
+    if (host === '0.0.0.0' || host === '::') {
+      host = '127.0.0.1'
+    }
+    shell.openExternal(`${protocol}://${host}:${port}${path}`).catch()
   }
 
   checkVersion()


### PR DESCRIPTION
## Summary

- Adds Docker Compose v2 fallback for the Podman compose integration.
- Keeps existing `docker-compose` support.
- Updates the n8n dashboard button to respect `N8N_PROTOCOL`, `N8N_HOST`, `N8N_PORT`, and `N8N_PATH`.

## Why

Modern Docker installations often provide Compose as `docker compose` instead of the standalone `docker-compose` binary.

The n8n dashboard button previously only read `N8N_PORT` and always opened `http://127.0.0.1:${port}`, ignoring existing n8n env settings for protocol, host, and path.

## Validation

- Verified `docker-compose --version`
- Verified `docker compose version`
- Verified n8n URL composition for custom protocol, host, port, and path