### PR TITLE
fix: resolve UI crash caused by .NET long version string parsing

### DIFF
--- a/src/render/components/VersionManager/static/index.vue
+++ b/src/render/components/VersionManager/static/index.vue
@@ -127,9 +127,13 @@
       dataKey: 'version',
       class: 'flex-shrink-0',
       headerClass: 'flex-shrink-0',
-      width: 200,
+      width: 280,
       cellRenderer: ({ rowData: row }) => {
-        return <span class="truncate">{row.version}</span>
+        return (
+          <ElTooltip show-after={600} placement="top" content={row.version}>
+            <span class="truncate">{row.version}</span>
+          </ElTooltip>
+        )
       }
     },
     {

--- a/src/render/components/VersionManager/static/index.vue
+++ b/src/render/components/VersionManager/static/index.vue
@@ -127,7 +127,7 @@
       dataKey: 'version',
       class: 'flex-shrink-0',
       headerClass: 'flex-shrink-0',
-      width: 280,
+      width: 200,
       cellRenderer: ({ rowData: row }) => {
         return (
           <ElTooltip show-after={600} placement="top" content={row.version}>

--- a/src/render/components/VersionManager/static/setup.ts
+++ b/src/render/components/VersionManager/static/setup.ts
@@ -88,7 +88,8 @@ export const Setup = (typeFlag: AllAppModule) => {
           continue
         }
       }
-      const nums = value.version.split('.').map((n: string, i: number) => {
+      const versionStr = value?.version || ''
+      const nums = versionStr.split('.').map((n: string, i: number) => {
         if (i > 0) {
           const num = parseInt(n)
           if (isNaN(num)) {
@@ -101,12 +102,8 @@ export const Setup = (typeFlag: AllAppModule) => {
         }
         return n
       })
-      const num = parseInt(nums.join(''))
-      Object.assign(value, {
-        version: value.version,
-        installed: value.installed,
-        num
-      })
+      const num = parseInt(nums.join('') || '0')
+      ;(value as any).num = num
       arr.push(value)
     }
     arr.sort((a: any, b: any) => compareVersions(versionFixed(b.version), versionFixed(a.version)))

--- a/src/render/core/Module/Module.ts
+++ b/src/render/core/Module/Module.ts
@@ -192,6 +192,7 @@ export class Module {
     this.brewFetching = true
     brewInfo(this.typeFlag)
       .then((res: any) => {
+        const newItems: any[] = []
         for (const item of res) {
           const find = this.brew.find((d) => d.name === item.name && d.version === item.version)
           if (!find) {
@@ -200,10 +201,13 @@ export class Module {
             obj.fetchCommand = obj.fetchCommand.bind(obj)
             obj.copyCommand = obj.copyCommand.bind(obj)
             obj.runCommand = obj.runCommand.bind(obj)
-            this.brew.push(obj)
+            newItems.push(obj)
           } else {
             Object.assign(find, item)
           }
+        }
+        if (newItems.length > 0) {
+          this.brew.push(...newItems)
         }
         this.brewFetching = false
       })
@@ -219,6 +223,7 @@ export class Module {
     this.portFetching = true
     portInfo(this.typeFlag)
       .then((res: any) => {
+        const newItems: any[] = []
         for (const item of res) {
           const find = this.port.find((d) => d.name === item.name && d.version === item.version)
           if (!find) {
@@ -227,10 +232,13 @@ export class Module {
             obj.fetchCommand = obj.fetchCommand.bind(obj)
             obj.copyCommand = obj.copyCommand.bind(obj)
             obj.runCommand = obj.runCommand.bind(obj)
-            this.port.push(obj)
+            newItems.push(obj)
           } else {
             Object.assign(find, item)
           }
+        }
+        if (newItems.length > 0) {
+          this.port.push(...newItems)
         }
         this.portFetching = false
       })
@@ -247,6 +255,7 @@ export class Module {
     fetchVerion(this.typeFlag)
       .then((res: any) => {
         console.log('fetchVerion res: ', res)
+        const newItems: any[] = []
         for (const item of res) {
           const find = this.static.find(
             (d) => d.url === item.url && d.version === item.version && d.bin === item.bin
@@ -256,14 +265,14 @@ export class Module {
               (d) => d.url === item.url && d.version === item.version && d.bin === item.bin
             )
             if (findDowing) {
-              this.static.push(findDowing)
+              newItems.push(findDowing)
             } else {
               const obj = reactive(new ModuleStaticItem(item))
               obj.typeFlag = this.typeFlag
               obj.fetchCommand = obj.fetchCommand.bind(obj)
               obj.copyCommand = obj.copyCommand.bind(obj)
               obj.runCommand = obj.runCommand.bind(obj)
-              this.static.push(obj)
+              newItems.push(obj)
             }
           } else {
             console.log('find: ', find, item)
@@ -271,6 +280,9 @@ export class Module {
             Object.assign(find, item)
             find.downing = downing
           }
+        }
+        if (newItems.length > 0) {
+          this.static.push(...newItems)
         }
         this.staticFetching = false
       })
@@ -286,15 +298,19 @@ export class Module {
     this.sdkmanFetching = true
     sdkmanInfo(this.typeFlag)
       .then((res: any) => {
+        const newItems: any[] = []
         for (const item of res) {
           const find = this.sdkman.find((d) => d.name === item.name && d.version === item.version)
           if (!find) {
             const obj = reactive(new ModuleSdkmanItem(item))
             obj.typeFlag = this.typeFlag
-            this.sdkman.push(obj)
+            newItems.push(obj)
           } else {
             Object.assign(find, item)
           }
+        }
+        if (newItems.length > 0) {
+          this.sdkman.push(...newItems)
         }
         this.sdkmanFetching = false
       })

--- a/src/render/util/Version.ts
+++ b/src/render/util/Version.ts
@@ -21,6 +21,7 @@ export function versionFixed(version?: string | null) {
         }
         return `${vn}`
       })
+      ?.slice(0, 3)
       ?.join('.') ?? '0'
   )
 }

--- a/src/shared/compare-versions.ts
+++ b/src/shared/compare-versions.ts
@@ -11,6 +11,7 @@ export function versionFixed(version?: string | null) {
         }
         return `${vn}`
       })
+      ?.slice(0, 3)
       ?.join('.') ?? '0'
   )
 }


### PR DESCRIPTION
### Describe the pull request

This PR addresses an issue where the `.NET` versions module gets stuck at "Getting available versions..." or crashes the UI when attempting to render long version strings (e.g. `11.0.100-preview.5.26302.115`).

**Changes include:**
1. **Fix `compare-versions` validation crash**: The `compare-versions` package throws an error when it encounters versions with more than 3 segments (e.g. `11.0.100.5.26302.115` generated by `versionFixed`). Updated `versionFixed` in both `src/render/util/Version.ts` and `src/shared/compare-versions.ts` to `slice(0, 3)` before joining, ensuring the version strictly complies with SemVer.
2. **Fix `el-table-v2` proxy spread reactivity issue**: In `src/render/components/VersionManager/static/setup.ts`, avoiding spreading a reactive proxy into a plain object (which breaks `downing` / `progress` tracking). 
3. **Batch data pushes**: Refactored `fetchStatic`, `fetchBrew`, `fetchPort`, and `fetchSdkman` in `Module.ts` to push array items in batch (`this.xxx.push(...newItems)`) rather than in a loop, minimizing unnecessary reactive update triggers.
4. **UI adjustment**: Added an `<ElTooltip>` to the Version column in `src/render/components/VersionManager/static/index.vue` so that when extremely long version strings like `.NET-11.0.100-preview.5.26302.115` get truncated, they are still fully legible on hover.