### PR TITLE
修复本地TLS小于1.2版本时，claude安装失败的问题。

### DIFF
--- a/src/render/components/ClaudeCode/Service.vue
+++ b/src/render/components/ClaudeCode/Service.vue
@@ -132,7 +132,7 @@
 
   const installCommand = computed(() => {
     if (window.Server.isWindows) {
-      return 'irm https://claude.ai/install.ps1 | iex'
+      return '[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; irm https://claude.ai/install.ps1 | iex'
     }
     return 'curl -fsSL https://claude.ai/install.sh | bash'
   })

--- a/src/render/components/ClaudeCode/setup.ts
+++ b/src/render/components/ClaudeCode/setup.ts
@@ -167,7 +167,7 @@ class ClaudeCode {
       (window.Server.Proxy ?? {}) as Record<string, string>
     )
     if (window.Server.isWindows) {
-      command.push('irm https://claude.ai/install.ps1 | iex')
+      command.push('[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12; irm https://claude.ai/install.ps1 | iex')
     } else {
       command.push('curl -fsSL https://claude.ai/install.sh | bash')
     }


### PR DESCRIPTION
When using in Windows, perform local TLS detection before installing claude. If it is less than 1.2, set the protocol to 1.2 first, and then execute the installation script. Claude does not support LTS1.1 version
在windows中使用时，安装claude前进行本地TLS检测，如果小于1.2，先设置协议到1.2，再执行安装脚本，claude 不支持 LTS1.1版本。