### PR TITLE
Enhance Windows Cron support and improve script testing

### DIFF
--- a/patches/vite-plugin-monaco-editor+1.1.0.patch
+++ b/patches/vite-plugin-monaco-editor+1.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/vite-plugin-monaco-editor/dist/workerMiddleware.js b/node_modules/vite-plugin-monaco-editor/dist/workerMiddleware.js
+index 5925339..10bcece 100644
+--- a/node_modules/vite-plugin-monaco-editor/dist/workerMiddleware.js
++++ b/node_modules/vite-plugin-monaco-editor/dist/workerMiddleware.js
+@@ -43,7 +43,7 @@ function workerMiddleware(middlewares, config, options) {
+     const works = index_1.getWorks(options);
+     // clear cacheDir
+     if (fs.existsSync(exports.cacheDir)) {
+-        fs.rmdirSync(exports.cacheDir, { recursive: true, force: true });
++        fs.rmSync(exports.cacheDir, { recursive: true, force: true });
+     }
+     for (const work of works) {
+         middlewares.use(config.base + options.publicPath + '/' + getFilenameByEntry(work.entry), function (req, res, next) {

--- a/scripts/phase4-install-terminal-cron-test.ts
+++ b/scripts/phase4-install-terminal-cron-test.ts
@@ -9,7 +9,10 @@ import {
   renderWindowsPipInstallScript,
   renderWindowsPythonInstallScript
 } from '../src/fork/module/Python/index'
-import { buildWindowsCronWrapperScript } from '../src/fork/module/Cron/WindowsSystemScheduler'
+import {
+  buildWindowsCronLauncherScript,
+  buildWindowsCronWrapperScript
+} from '../src/fork/module/Cron/WindowsSystemScheduler'
 import { buildWindowsTerminalInlineScript } from '../src/shared/WindowsTerminal'
 import { powerShellInlineArgs } from '../src/shared/PowerShellCommand'
 
@@ -61,10 +64,19 @@ assert.ok(!cronWrapper.includes('$CmdFile'))
 assert.ok(!cronWrapper.includes('WriteAllText($CmdFile'))
 assert.ok(!cronWrapper.includes('.cmd'))
 
+const cronLauncher = buildWindowsCronLauncherScript({
+  powerShell: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  scriptPath: 'C:\\FlyEnv\\cron\\tasks\\job-1.ps1'
+})
+assert.ok(cronLauncher.includes('CreateObject("WScript.Shell")'))
+assert.ok(cronLauncher.includes(', 0, True)'))
+assert.ok(cronLauncher.includes('-WindowStyle Hidden'))
+
 const cronLockRoot = await mkdtemp(join(tmpdir(), 'flyenv-cron-lock-'))
 const cronLockRunDir = join(cronLockRoot, 'tmp')
 const cronLockLogFile = join(cronLockRoot, 'runs', 'job-lock.jsonl')
 const cronLockScript = join(cronLockRoot, 'job-lock.ps1')
+const cronLockLauncher = join(cronLockRoot, 'job-lock.vbs')
 const cronLockDir = join(cronLockRunDir, 'job-lock.lock')
 const utf8Output = 'FlyEnv 中文输出'
 const utf8OutputBase64 = Buffer.from(utf8Output, 'utf-8').toString('base64')
@@ -87,16 +99,18 @@ try {
     })
   )
 
-  const powerShell = join(
-    process.env.SystemRoot || 'C:\\Windows',
-    'System32',
-    'WindowsPowerShell',
-    'v1.0',
-    'powershell.exe'
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows'
+  const powerShell = join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+  await writeFile(
+    cronLockLauncher,
+    buildWindowsCronLauncherScript({
+      powerShell,
+      scriptPath: cronLockScript
+    })
   )
   const result = await execFileAsync(
-    powerShell,
-    ['-NoProfile', '-NonInteractive', '-File', cronLockScript],
+    join(systemRoot, 'System32', 'wscript.exe'),
+    ['//B', '//Nologo', cronLockLauncher],
     {
       encoding: 'utf-8',
       timeout: 15_000,

--- a/scripts/phase4-install-terminal-cron-test.ts
+++ b/scripts/phase4-install-terminal-cron-test.ts
@@ -1,4 +1,9 @@
 import assert from 'node:assert/strict'
+import { mkdtemp, mkdir, readFile, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
 
 import {
   renderWindowsPipInstallScript,
@@ -7,6 +12,8 @@ import {
 import { buildWindowsCronWrapperScript } from '../src/fork/module/Cron/WindowsSystemScheduler'
 import { buildWindowsTerminalInlineScript } from '../src/shared/WindowsTerminal'
 import { powerShellInlineArgs } from '../src/shared/PowerShellCommand'
+
+const execFileAsync = promisify(execFile)
 
 const pythonInstall = renderWindowsPythonInstallScript(
   'cd "#DARKDIR#"\n./dark.exe -x "#TMPL#" "#EXE#"\n$targetDir = "#APPDIR#"',
@@ -49,9 +56,62 @@ const cronWrapper = buildWindowsCronWrapperScript({
   envPath: 'C:\\Windows\\System32'
 })
 assert.ok(cronWrapper.includes('$psi.FileName = $CmdExe'))
-assert.ok(cronWrapper.includes("$psi.Arguments = '/d /s /c ' + $Command"))
+assert.ok(cronWrapper.includes("$psi.Arguments = '/d /c ' + $Command"))
 assert.ok(!cronWrapper.includes('$CmdFile'))
 assert.ok(!cronWrapper.includes('WriteAllText($CmdFile'))
 assert.ok(!cronWrapper.includes('.cmd'))
+
+const cronLockRoot = await mkdtemp(join(tmpdir(), 'flyenv-cron-lock-'))
+const cronLockRunDir = join(cronLockRoot, 'tmp')
+const cronLockLogFile = join(cronLockRoot, 'runs', 'job-lock.jsonl')
+const cronLockScript = join(cronLockRoot, 'job-lock.ps1')
+const cronLockDir = join(cronLockRunDir, 'job-lock.lock')
+const utf8Output = 'FlyEnv 中文输出'
+const utf8OutputBase64 = Buffer.from(utf8Output, 'utf-8').toString('base64')
+
+try {
+  await mkdir(cronLockDir, { recursive: true })
+  const staleAt = new Date(Date.now() - 10 * 60 * 1000)
+  await utimes(cronLockDir, staleAt, staleAt)
+  await writeFile(
+    cronLockScript,
+    buildWindowsCronWrapperScript({
+      jobId: 'job-lock',
+      scope: 'global',
+      command: `powershell -NoProfile -Command "[Console]::OutputEncoding = [Text.UTF8Encoding]::new(); [Console]::Write([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${utf8OutputBase64}')))"`,
+      workDir: cronLockRoot,
+      runDir: cronLockRunDir,
+      logFile: cronLockLogFile,
+      cmdExe: join(process.env.SystemRoot || 'C:\\Windows', 'System32', 'cmd.exe'),
+      envPath: process.env.Path || process.env.PATH || ''
+    })
+  )
+
+  const powerShell = join(
+    process.env.SystemRoot || 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  )
+  const result = await execFileAsync(
+    powerShell,
+    ['-NoProfile', '-NonInteractive', '-File', cronLockScript],
+    {
+      encoding: 'utf-8',
+      timeout: 15_000,
+      windowsHide: true
+    }
+  )
+  assert.equal(result.stderr, '')
+
+  const records = (await readFile(cronLockLogFile, 'utf-8')).trim().split(/\r?\n/)
+  assert.equal(records.length, 1)
+  const record = JSON.parse(records[0])
+  assert.equal(record.exitCode, 0)
+  assert.equal(record.output, utf8Output)
+} finally {
+  await rm(cronLockRoot, { recursive: true, force: true })
+}
 
 console.log('phase4 install terminal cron tests passed')

--- a/scripts/vite-monaco-node-compat-test.ts
+++ b/scripts/vite-monaco-node-compat-test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import { createServer } from 'vite'
+import viteConfigs from '../configs/vite.config'
+
+const server = await createServer(viteConfigs.serverConfig)
+
+try {
+  assert.ok(server.middlewares)
+} finally {
+  await server.close()
+}
+
+console.log('vite monaco Node compatibility test passed')

--- a/src/fork/module/Cron/WindowsSystemScheduler.ts
+++ b/src/fork/module/Cron/WindowsSystemScheduler.ts
@@ -19,6 +19,27 @@ type WindowsCronWrapperScriptParams = {
   envPath: string
 }
 
+type WindowsCronLauncherScriptParams = {
+  powerShell: string
+  scriptPath: string
+}
+
+function vbString(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`
+}
+
+export function buildWindowsCronLauncherScript(params: WindowsCronLauncherScriptParams): string {
+  const command = `${vbString(params.powerShell)} -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File ${vbString(params.scriptPath)}`
+
+  return `Option Explicit
+Dim shell
+Dim command
+command = ${vbString(command)}
+Set shell = CreateObject("WScript.Shell")
+WScript.Quit shell.Run(command, 0, True)
+`
+}
+
 export function buildWindowsCronWrapperScript(params: WindowsCronWrapperScriptParams): string {
   return `$ErrorActionPreference = 'Continue'
 $JobId = '${params.jobId}'
@@ -122,7 +143,7 @@ export class WindowsSystemScheduler {
     return runLogPath(this.cronRoot, jobId)
   }
 
-  private taskScriptPath(jobId: string, ext: 'ps1' | 'cmd'): string {
+  private taskScriptPath(jobId: string, ext: 'ps1' | 'cmd' | 'vbs'): string {
     return taskScriptPath(this.cronRoot, jobId, ext)
   }
 
@@ -178,6 +199,16 @@ export class WindowsSystemScheduler {
     return candidates.find((path) => existsSync(path)) || 'powershell.exe'
   }
 
+  private async windowsScriptHostPath(): Promise<string> {
+    await this.syncEnv()
+    const systemRoot = this.systemRoot()
+    const candidates = [
+      join(systemRoot, 'Sysnative', 'wscript.exe'),
+      join(systemRoot, 'System32', 'wscript.exe')
+    ]
+    return candidates.find((path) => existsSync(path)) || 'wscript.exe'
+  }
+
   private async resolvePath(): Promise<string> {
     await this.syncEnv()
     const env = { ...process.env, ...(EnvSync.AppEnv ?? {}) }
@@ -186,6 +217,7 @@ export class WindowsSystemScheduler {
 
   private async writeWrapper(job: CronJob): Promise<string> {
     const psFile = this.taskScriptPath(job.id, 'ps1')
+    const vbsFile = this.taskScriptPath(job.id, 'vbs')
     const workDir = job.workDir || homePath()
     const runDir = join(this.cronRoot, 'tmp')
     const logFile = this.runLogPath(job.id)
@@ -208,7 +240,14 @@ export class WindowsSystemScheduler {
 
     await mkdirp(dirname(psFile))
     await writeFile(psFile, psContent)
-    return `${this.cmdQuote(powerShell)} -NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File ${this.cmdQuote(psFile)}`
+    await writeFile(
+      vbsFile,
+      buildWindowsCronLauncherScript({
+        powerShell,
+        scriptPath: psFile
+      })
+    )
+    return `${this.cmdQuote(await this.windowsScriptHostPath())} //B //Nologo ${this.cmdQuote(vbsFile)}`
   }
 
   private taskTime(hour: number, minute: number): string {
@@ -301,6 +340,7 @@ export class WindowsSystemScheduler {
   async remove(jobId: string) {
     await this.removeTask(jobId)
     await remove(this.taskScriptPath(jobId, 'ps1')).catch(() => {})
+    await remove(this.taskScriptPath(jobId, 'vbs')).catch(() => {})
     await remove(this.taskScriptPath(jobId, 'cmd')).catch(() => {})
   }
 

--- a/src/fork/module/Cron/WindowsSystemScheduler.ts
+++ b/src/fork/module/Cron/WindowsSystemScheduler.ts
@@ -34,10 +34,23 @@ $env:Path = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${base6
 New-Item -ItemType Directory -Force -Path $RunDir | Out-Null
 New-Item -ItemType Directory -Force -Path (Split-Path -Parent $LogFile) | Out-Null
 $LockDir = Join-Path $RunDir "$JobId.lock"
+$LockMaxAgeSeconds = 300
+$LockAcquired = $false
 try {
   New-Item -ItemType Directory -Path $LockDir -ErrorAction Stop | Out-Null
+  $LockAcquired = $true
 } catch {
-  exit 0
+  try {
+    $lockAgeSeconds = ([DateTime]::UtcNow - (Get-Item -LiteralPath $LockDir -ErrorAction Stop).LastWriteTimeUtc).TotalSeconds
+    if ($lockAgeSeconds -ge $LockMaxAgeSeconds) {
+      Remove-Item -Recurse -Force -LiteralPath $LockDir -ErrorAction Stop
+      New-Item -ItemType Directory -Path $LockDir -ErrorAction Stop | Out-Null
+      $LockAcquired = $true
+    }
+  } catch {}
+  if (-not $LockAcquired) {
+    exit 0
+  }
 }
 
 $RunId = "$(Get-Date -Format yyyyMMddHHmmss)-$PID"
@@ -45,10 +58,7 @@ $OutFile = Join-Path $RunDir "$JobId-$RunId.out"
 $ErrFile = Join-Path $RunDir "$JobId-$RunId.err"
 $StartedAt = [DateTimeOffset]::Now.ToUnixTimeMilliseconds()
 $ExitCode = 0
-$CmdEncoding = [Text.Encoding]::Default
-try {
-  $CmdEncoding = [Text.Encoding]::GetEncoding([Globalization.CultureInfo]::CurrentCulture.TextInfo.OEMCodePage)
-} catch {}
+$CmdEncoding = [Text.UTF8Encoding]::new($false)
 
 try {
   if (-not (Test-Path -LiteralPath $WorkDir -PathType Container)) {

--- a/src/fork/module/Cron/types.ts
+++ b/src/fork/module/Cron/types.ts
@@ -17,7 +17,7 @@ export interface CronCommandResult {
   duration: number
 }
 
-export type CronTaskScriptExt = 'sh' | 'ps1' | 'cmd'
+export type CronTaskScriptExt = 'sh' | 'ps1' | 'cmd' | 'vbs'
 
 export const GLOBAL_HOST_ID = 0
 export const RUN_HISTORY_LIMIT = 50


### PR DESCRIPTION
test(scripts): 添加 Windows Cron 启动脚本测试用例

- 增加 buildWindowsCronLauncherScript 函数单元测试覆盖
- 验证生成的 VBScript 启动脚本中包含 WScript.Shell 创建和隐藏窗口运行相关代码
- 测试中添加对生成的启动脚本文本内容的断言

feat(Cron): 支持 Windows Cron VBS 启动脚本

- 新增 buildWindowsCronLauncherScript 用于生成调用 PowerShell 的 VBScript
- 扩展 CronTaskScriptExt 类型，增加 'vbs' 脚本格式支持
- 在 WindowsSystemScheduler 模块添加生成和写入 VBS 启动脚本逻辑
- 修改任务脚本路径支持 'vbs' 后缀
- 在写入 Wrapper 时同时生成 VBS 启动脚本，执行时通过 wscript.exe 启动
- 添加获取 wscript.exe 路径方法，优先查找 Sysnative 和 System32 目录
- 任务删除时同时删除对应的 vbs 启动脚本文件

refactor(scripts): 使用集中变量管理系统路径

- 统一使用 systemRoot 变量获取系统根目录
- 将系统路径连接操作集中处理，增强代码可读性和一致性

test(vite): 新增 vite monaco Node 兼容性测试用例

- 创建 vite 服务实例
- 验证中间件是否正确加载
- 在测试完成后关闭服务

fix(vite-plugin-monaco-editor): 替换过时的 fs.rmdirSync 调用

- 将 fs.rmdirSync 替换为 fs.rmSync 以兼容最新 Node 版本
- 保持功能行为不变，继续递归删除缓存目录

最终效果：定时任务不在弹出终端，并闪退，而是直接在后台执行，修复一个node-26  yarn dev 启动报错问题