### PR TITLE
Fix SiteSucker proxy configuration updates

### DIFF
--- a/scripts/site-sucker-config-test.ts
+++ b/scripts/site-sucker-config-test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import Config from '../src/main/ui/SiteSucker/Config'
+
+Config.update({
+  dir: '/tmp/site-sucker',
+  proxy: ' http://127.0.0.1:1087 ',
+  excludeLink: ' example.com\n\n static.example.com ',
+  pageLimit: ' docs.example.com ',
+  timeout: 12_000,
+  maxImgSize: 5,
+  maxVideoSize: 25,
+  maxRetryTimes: 6,
+  windowCount: 3
+})
+
+assert.equal(Config.dir, '/tmp/site-sucker')
+assert.equal(Config.proxy, 'http://127.0.0.1:1087')
+assert.equal(Config.excludeLink, 'example.com\n\n static.example.com')
+assert.equal(Config.pageLimit, 'docs.example.com')
+assert.equal(Config.timeout, 12_000)
+assert.equal(Config.maxImgSize, 5)
+assert.equal(Config.maxVideoSize, 25)
+assert.equal(Config.maxRetryTimes, 6)
+assert.equal(Config.windowCount, 3)
+assert.deepEqual(Config.ExcludeHost.slice(-2), ['example.com', 'static.example.com'])
+
+Config.update({
+  dir: '',
+  proxy: '   ',
+  excludeLink: '',
+  pageLimit: '',
+  timeout: Number.NaN,
+  maxImgSize: -1,
+  maxVideoSize: Number.POSITIVE_INFINITY,
+  maxRetryTimes: -1,
+  windowCount: 0
+})
+
+assert.equal(Config.dir, '')
+assert.equal(Config.proxy, '', 'clearing the proxy must clear the active runtime proxy')
+assert.equal(Config.excludeLink, '')
+assert.equal(Config.pageLimit, '')
+assert.equal(Config.timeout, 5_000)
+assert.equal(Config.maxImgSize, 0)
+assert.equal(Config.maxVideoSize, 0)
+assert.equal(Config.maxRetryTimes, 3)
+assert.equal(Config.windowCount, 2)
+
+const ipcHandlerSource = readFileSync('src/main/core/IPCHandler.ts', 'utf8')
+assert.match(
+  ipcHandlerSource,
+  /siteSuckerRuntime\.peek\(\)\?\.updateConfig\(args\[0\]\?\.commonSetup\)/,
+  'live settings updates must unwrap the persisted commonSetup payload'
+)
+
+const siteSuckerSource = readFileSync('src/main/ui/SiteSucker/index.ts', 'utf8')
+assert.match(siteSuckerSource, /PageTask\.init\(Config\.windowCount\)/)
+
+const pageTaskSource = readFileSync('src/main/ui/SiteSucker/PageTask.ts', 'utf8')
+assert.match(pageTaskSource, /if \(Config\.proxy\.trim\(\)\)/)
+assert.match(pageTaskSource, /setProxy\(\{\s*proxyRules: proxy\s*\}\)/)
+
+const rendererStoreSource = readFileSync('src/render/components/Tools/SiteSucker/store.ts', 'utf8')
+for (const field of ['timeout', 'maxImgSize', 'maxVideoSize', 'maxRetryTimes', 'windowCount']) {
+  assert.match(rendererStoreSource, new RegExp(`${field}: number`))
+}
+
+console.log('site sucker config tests passed')

--- a/src/main/core/IPCHandler.ts
+++ b/src/main/core/IPCHandler.ts
@@ -796,7 +796,7 @@ export default class IPCHandler extends EventEmitter {
   private handleSiteSuckerSetupSave(command: string, key: string, args: any[]) {
     this.deps.configManager.setConfig('tools.siteSucker', args[0])
     this.sendToMainWindow(command, key, true)
-    siteSuckerRuntime.peek()?.updateConfig(args[0])
+    siteSuckerRuntime.peek()?.updateConfig(args[0]?.commonSetup)
   }
 
   // ===== OAuth =====

--- a/src/main/ui/SiteSucker/Config.ts
+++ b/src/main/ui/SiteSucker/Config.ts
@@ -19,6 +19,18 @@ const BaseExcludeHost = [
   'www.google.com'
 ]
 
+const numberOrDefault = (value: unknown, fallback: number, minimum: number, integer = false) => {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < minimum ||
+    (integer && !Number.isInteger(value))
+  ) {
+    return fallback
+  }
+  return value
+}
+
 class Config implements RunConfig {
   dir: string = ''
   excludeLink: string = ''
@@ -27,47 +39,32 @@ class Config implements RunConfig {
   maxVideoSize: number = 0
   pageLimit: string = ''
   proxy: string = ''
-  timeout: number = 6000
-  windowCount = 4
+  timeout: number = 5000
+  windowCount = 2
   ExcludeHost: string[] = []
 
   constructor() {}
 
-  update(config: RunConfig) {
+  update(config: Partial<RunConfig> = {}) {
+    this.dir = typeof config.dir === 'string' ? config.dir : ''
+    this.proxy = typeof config.proxy === 'string' ? config.proxy.trim() : ''
+    this.excludeLink = typeof config.excludeLink === 'string' ? config.excludeLink.trim() : ''
+    this.pageLimit = typeof config.pageLimit === 'string' ? config.pageLimit.trim() : ''
+    this.timeout = numberOrDefault(config.timeout, 5000, 1)
+    this.maxImgSize = numberOrDefault(config.maxImgSize, 0, 0)
+    this.maxVideoSize = numberOrDefault(config.maxVideoSize, 0, 0)
+    this.maxRetryTimes = numberOrDefault(config.maxRetryTimes, 3, 0, true)
+    this.windowCount = numberOrDefault(config.windowCount, 2, 1, true)
+
     this.ExcludeHost.splice(0)
     this.ExcludeHost.push(...BaseExcludeHost)
 
-    if (config?.excludeLink?.trim()) {
-      const excludes = config.excludeLink
-        .trim()
+    if (this.excludeLink) {
+      const excludes = this.excludeLink
         .split('\n')
         .filter((f) => !!f.trim())
         .map((m) => m.trim())
       this.ExcludeHost.push(...excludes)
-    }
-
-    if (config?.pageLimit?.trim()) {
-      this.pageLimit = config.pageLimit.trim()
-    } else {
-      this.pageLimit = ''
-    }
-
-    if (config?.timeout) {
-      this.timeout = config.timeout
-    } else {
-      this.timeout = 5000
-    }
-
-    if (config?.maxImgSize) {
-      this.maxImgSize = config.maxImgSize
-    } else {
-      this.maxImgSize = 0
-    }
-
-    if (config?.maxVideoSize) {
-      this.maxVideoSize = config.maxVideoSize
-    } else {
-      this.maxVideoSize = 0
     }
   }
 }

--- a/src/main/ui/SiteSucker/index.ts
+++ b/src/main/ui/SiteSucker/index.ts
@@ -24,9 +24,9 @@ class SiteSucker {
     const urlObj = new URL(url)
     urlObj.hash = ''
     url = urlObj.toString()
-    Store.host = urlObj.host
-    Store.dir = join(item.config.dir, urlObj.host)
     Config.update(item.config)
+    Store.host = urlObj.host
+    Store.dir = join(Config.dir, urlObj.host)
 
     const saveFile = urlToDir(url, true)
     const currentPage: PageLink = {
@@ -36,7 +36,7 @@ class SiteSucker {
       type: 'text/html'
     }
     Store.Pages.push(new LinkItem(currentPage))
-    PageTask.init(item?.config?.windowCount ?? 2)
+    PageTask.init(Config.windowCount)
     LinkTask.init(CPU_Count - 1)
     PageTask.updateConfig()
     PageTask.run().then()

--- a/src/render/components/Tools/SiteSucker/store.ts
+++ b/src/render/components/Tools/SiteSucker/store.ts
@@ -17,6 +17,11 @@ export type SiteSuckerSetup = {
   proxy: string
   excludeLink: string
   pageLimit: string
+  timeout: number
+  maxImgSize: number
+  maxVideoSize: number
+  maxRetryTimes: number
+  windowCount: number
 }
 
 export type SiteSuckerTask = {
@@ -40,7 +45,12 @@ const state: State = {
     dir: '',
     proxy: '',
     excludeLink: '',
-    pageLimit: ''
+    pageLimit: '',
+    timeout: 5000,
+    maxImgSize: 0,
+    maxVideoSize: 0,
+    maxRetryTimes: 3,
+    windowCount: 2
   }
 }
 


### PR DESCRIPTION
## Summary

- copy and validate the complete SiteSucker runtime configuration, including `proxy`
- unwrap the persisted `commonSetup` payload before applying live settings updates
- use the validated directory and window count when starting a task
- align the renderer `SiteSuckerSetup` type and defaults with the main-process configuration
- add focused regression coverage for valid, cleared, and invalid settings

## Root cause

`Config.update()` updated only page limits, timeout, and media sizes, so the proxy entered in settings never reached `Config.proxy`. In addition, the live settings-save path passed the outer `{ commonSetup }` persistence object to a runtime method that expects the inner configuration.

## Impact

Saved proxy settings now reach Electron session proxy configuration and the HTTP/HTTPS agents both when a task starts and when settings are changed while the SiteSucker runtime is loaded. Clearing the proxy also clears the active runtime value. Invalid numeric settings fall back to the existing safe defaults.

## Validation

- `npx --yes tsx@4.20.3 scripts/site-sucker-config-test.ts`
- strict TypeScript check of `src/main/ui/SiteSucker/Config.ts`
- targeted esbuild bundles of the SiteSucker runtime, IPC handler, and renderer store
- `npx --yes prettier@3.6.1 --check src/main/core/IPCHandler.ts src/main/ui/SiteSucker/Config.ts src/main/ui/SiteSucker/index.ts src/render/components/Tools/SiteSucker/store.ts scripts/site-sucker-config-test.ts`
- `git diff --check`

The full repository test suite was not run because dependencies are not installed in the current checkout.
