### PR TITLE
fix(i18n): translate 3 untranslated keys in Indonesian common.json

### DIFF
--- a/src/lang/id/common.json
+++ b/src/lang/id/common.json
@@ -11,7 +11,7 @@
     "errorLog": "Log Error",
     "library": "Library",
     "path": "Path",
-    "description": "Description",
+    "description": "Deskripsi",
     "port": "Port",
     "startCommand": "Perintah Mulai",
     "licenseDescription": "Deskripsi Lisensi",
@@ -78,7 +78,7 @@
     "mcp": "MCP",
     "skills": "Keterampilan",
     "basicInfo": "Informasi Dasar",
-    "configuration": "Configuration",
+    "configuration": "Konfigurasi",
     "favorites": "Favorit",
     "plugins": "Plugin",
     "backupUpdate": "Cadangan & Pembaruan"
@@ -120,7 +120,7 @@
     "other": "Lainnya",
     "default": "Default",
     "none": "Tidak ada",
-    "local": "Local"
+    "local": "Lokal"
   },
   "plugin": {
     "search": "Cari plugin",


### PR DESCRIPTION
## Changes

Fix 3 keys in `src/lang/id/common.json` that were left in English:

| Key | Before | After |
|-----|--------|-------|
| `label.description` | `"Description"` | `"Deskripsi"` |
| `category.configuration` | `"Configuration"` | `"Konfigurasi"` |
| `value.local` | `"Local"` | `"Lokal"` |

## Verification

All 3 keys verified against English source (`src/lang/en/common.json`).