### PR TITLE
Fix SiteSucker window lifecycle cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:main-lazy-runtime": "tsx scripts/main-process-lazy-runtime-test.ts",
     "test:capturer-shortcut": "tsx scripts/capturer-shortcut-startup-test.ts",
     "test:window-page-options": "tsx scripts/window-page-options-test.ts",
+    "test:site-sucker-window-lifecycle": "tsx scripts/site-sucker-window-lifecycle-test.ts",
     "test:main-lazy-bundle": "tsx scripts/main-process-lazy-bundle-test.ts",
     "test:main-lazy-utilities": "tsx scripts/main-process-eager-utilities-test.ts",
     "test:main-resource-path": "tsx scripts/main-process-resource-path-test.ts",

--- a/scripts/site-sucker-window-lifecycle-test.ts
+++ b/scripts/site-sucker-window-lifecycle-test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync('src/main/ui/SiteSucker/PageTask.ts', 'utf8')
+const constructorSource = source.slice(
+  source.indexOf('constructor('),
+  source.indexOf('async updateConfig')
+)
+const headersHandlerSource = constructorSource.slice(
+  constructorSource.indexOf('onHeadersReceived'),
+  constructorSource.length
+)
+const pageTaskSource = source.slice(source.indexOf('class PageTask {'))
+
+assert.equal(
+  constructorSource.match(/\.once\('closed'/g)?.length,
+  1,
+  'each SiteSucker window must register exactly one closed listener during construction'
+)
+assert.doesNotMatch(
+  headersHandlerSource,
+  /\.on\('close'/,
+  'response handling must not register additional window close listeners'
+)
+assert.match(
+  source,
+  /private handleWindowClosed = \(\) => \{[\s\S]*?this\.onDestroyed\(this\)/,
+  'window cleanup must notify the task manager through one shared finalizer'
+)
+assert.match(
+  source,
+  /destroy\(\) \{[\s\S]*?if \(this\.destroyed\) \{[\s\S]*?return[\s\S]*?window\.destroy\(\)[\s\S]*?this\.handleWindowClosed\(\)/,
+  'window destruction must be idempotent and finalize even if Electron does not emit synchronously'
+)
+assert.match(
+  pageTaskSource,
+  /destroy\(\) \{[\s\S]*?const task = \[\.\.\.this\.task\][\s\S]*?task\.forEach\(\(t\) => t\.destroy\(\)\)/,
+  'destroying the SiteSucker task manager must destroy every BrowserWindow'
+)
+
+console.log('SiteSucker window lifecycle tests passed')

--- a/src/main/ui/SiteSucker/PageTask.ts
+++ b/src/main/ui/SiteSucker/PageTask.ts
@@ -10,10 +10,12 @@ import { dirname } from 'path'
 
 class PageTaskItem {
   private window?: BrowserWindow
+  private destroyed = false
+  private onDestroyed: (item: PageTaskItem) => void
   isDestroy?: boolean
-  onDestroyed?: (item: any) => void
 
-  constructor() {
+  constructor(onDestroyed: (item: PageTaskItem) => void) {
+    this.onDestroyed = onDestroyed
     this.window = new BrowserWindow({
       show: true,
       width: 1440,
@@ -24,6 +26,7 @@ class PageTaskItem {
         webSecurity: false
       }
     })
+    this.window.once('closed', this.handleWindowClosed)
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
       if (checkIsExcludeUrl(details.url, false)) {
         callback({
@@ -138,12 +141,19 @@ class PageTaskItem {
         }
         callback({})
       }
-      this?.window?.on('close', async () => {
-        this.destroy()
-        this?.onDestroyed?.(this)
-      })
     })
   }
+
+  private handleWindowClosed = () => {
+    if (this.destroyed) {
+      return
+    }
+    this.destroyed = true
+    this.isDestroy = true
+    this.window = undefined
+    this.onDestroyed(this)
+  }
+
   async updateConfig() {
     if (Config.proxy.trim()) {
       const proxy = Config.proxy.trim()
@@ -432,29 +442,37 @@ class PageTaskItem {
   }
 
   destroy() {
-    this.isDestroy = true
-    if (this.window) {
-      this.window?.destroy()
+    if (this.destroyed) {
+      return
     }
-    this.window = undefined
+    this.isDestroy = true
+    const window = this.window
+    if (window && !window.isDestroyed()) {
+      window.destroy()
+    }
+    this.handleWindowClosed()
   }
 }
 
 class PageTask {
   private task: PageTaskItem[] = []
-  init(num: number) {
-    const destroy = (item: any) => {
-      const index = this.task.findIndex((f) => f === item)
-      if (index >= 0) {
-        this.task.splice(index, 1)
-      }
-      if (this.task.length === 0) {
-        Callback.fn('window-close')
-      }
+  private closeNotified = false
+
+  private handleDestroyed = (item: PageTaskItem) => {
+    const index = this.task.findIndex((task) => task === item)
+    if (index >= 0) {
+      this.task.splice(index, 1)
     }
+    if (this.task.length === 0 && !this.closeNotified) {
+      this.closeNotified = true
+      Callback.fn('window-close')
+    }
+  }
+
+  init(num: number) {
+    this.closeNotified = false
     for (let i = 0; i < num; i += 1) {
-      const item = new PageTaskItem()
-      item.onDestroyed = destroy
+      const item = new PageTaskItem(this.handleDestroyed)
       this.task.push(item)
     }
   }
@@ -471,10 +489,8 @@ class PageTask {
     this.task.forEach((t) => t.updateConfig())
   }
   destroy() {
-    this.task.forEach((t) => {
-      t.isDestroy = true
-    })
-    this.task.splice(0)
+    const task = [...this.task]
+    task.forEach((t) => t.destroy())
   }
 }
 


### PR DESCRIPTION
## Summary

- register one `closed` listener when each SiteSucker window is created instead of adding a `close` listener for every response
- make window finalization idempotent so task removal and stop notification happen only once
- destroy every tracked `BrowserWindow` when the SiteSucker task manager is stopped
- add a focused regression test for the SITE-02 lifecycle requirements

## Verification

- `npx --yes tsx@4.20.3 scripts/site-sucker-window-lifecycle-test.ts`
- `npx prettier --check package.json src/main/ui/SiteSucker/PageTask.ts scripts/site-sucker-window-lifecycle-test.ts`
- targeted esbuild bundle of `src/main/ui/SiteSucker/PageTask.ts`
