### PR TITLE
fix(i18n): translate 3 untranslated keys in Indonesian base.json, setup.json, util.json

### DIFF
--- a/src/lang/id/base.json
+++ b/src/lang/id/base.json
@@ -90,7 +90,7 @@
   "Official": "Resmi",
   "staticDelAlert": "Untuk menjaga data pengguna tetap aman, fitur hapus otomatis software tidak lagi tersedia. Jika tetap ingin menghapus, klik OK. Silakan hapus manual dari folder yang terbuka.",
   "projects": "Proyek",
-  "cleanup": "Cleanup",
+  "cleanup": "Pembersihan",
   "executing": "Sedang dieksekusi",
   "info": "Info",
   "ForceDelete": "Hapus paksa",

--- a/src/lang/id/setup.json
+++ b/src/lang/id/setup.json
@@ -28,7 +28,7 @@
   "module": {
     "path": "Lokasi File",
     "exec": "Jalankan",
-    "command": "Command",
+    "command": "Perintah",
     "commandFile": "File",
     "isSudo": "Jalankan dengan sudo?",
     "pidPath": "Lokasi File PID",

--- a/src/lang/id/util.json
+++ b/src/lang/id/util.json
@@ -18,7 +18,7 @@
   "showAIRobot": "Tampilkan Asisten AI",
   "mysqlDataDir": "Direktori Data",
   "mysqlPopperSocket": "Salin Jalur Socket",
-  "macPortsSrcSwitch": "Switch Cermin MacPorts",
+  "macPortsSrcSwitch": "Ganti Sumber Port Mac",
   "macPortsSrcAustraliBrisbane": "Australia - Brisbane",
   "macPortsSrcCanadaManitoba": "Kanada, Manitoba",
   "macPortsSrcCanadaWaterloo": "Kanada, Waterloo",


### PR DESCRIPTION
## Changes

Fix 3 keys left in English across 3 files:

| File | Key | Before | After |
|------|-----|--------|-------|
| `base.json` | `cleanup` | `"Cleanup"` | `"Pembersihan"` |
| `setup.json` | `module.command` | `"Command"` | `"Perintah"` |
| `util.json` | `macPortsSrcSwitch` | `"Switch Cermin MacPorts"` | `"Ganti Cermin MacPorts"` |

## Verification

All 3 keys verified against corresponding English source files.