### PR TITLE
fix: Temporal config init and ClickHouse log viewer improvements

### DIFF
--- a/src/render/components/ClickHouse/Logs.vue
+++ b/src/render/components/ClickHouse/Logs.vue
@@ -1,7 +1,17 @@
 <template>
   <div class="module-config">
     <el-card>
-      <LogVM ref="log" :log-file="filepath" />
+      <template #header>
+        <el-radio-group v-model="logType">
+          <el-radio-button
+            v-for="f in files"
+            :key="f.path"
+            :label="f.name"
+            :value="f.path"
+          ></el-radio-button>
+        </el-radio-group>
+      </template>
+      <LogVM ref="log" :key="logType" :log-file="logType" />
       <template #footer>
         <ToolVM :log="log" />
       </template>
@@ -10,13 +20,38 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, ref } from 'vue'
+  import { computed, ref, watch } from 'vue'
   import LogVM from '@/components/Log/index.vue'
   import ToolVM from '@/components/Log/tool.vue'
   import { join } from '@/util/path-browserify'
 
   const log = ref()
-  const filepath = computed(() => {
-    return join(window.Server.ClickHouseDir!, 'log/server.log')
+
+  const files = computed(() => {
+    const dir = window.Server.ClickHouseDir
+    if (!dir) {
+      return []
+    }
+    const logDir = join(dir, 'log')
+    return [
+      { name: 'server', path: join(logDir, 'server.log') },
+      { name: 'error', path: join(logDir, 'server.err.log') },
+      { name: 'start-out', path: join(logDir, 'server.start.out.log') },
+      { name: 'start-error', path: join(logDir, 'server.start.err.log') },
+      { name: 'ch-ui-start-out', path: join(dir, 'ch-ui/log/ch-ui.start.out.log') },
+      { name: 'ch-ui-start-error', path: join(dir, 'ch-ui/log/ch-ui.start.err.log') }
+    ]
   })
+
+  const logType = ref('')
+
+  watch(
+    files,
+    (list) => {
+      if (!logType.value || !list.some((f) => f.path === logType.value)) {
+        logType.value = list?.[0]?.path ?? ''
+      }
+    },
+    { immediate: true }
+  )
 </script>

--- a/src/render/components/Temporal/Config.vue
+++ b/src/render/components/Temporal/Config.vue
@@ -54,6 +54,9 @@
   const invokeTemporal = (...args: any[]) => {
     return new Promise<any>((resolve) => {
       IPC.send('app-fork:temporal', ...args).then((key: string, res: any) => {
+        if (res?.code === 200) {
+          return
+        }
         IPC.off(key)
         resolve(res)
       })

--- a/src/render/components/TemporalCli/Config.vue
+++ b/src/render/components/TemporalCli/Config.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, ref } from 'vue'
+  import { computed, nextTick, ref, watch } from 'vue'
   import Conf from '@/components/Conf/index.vue'
   import IPC from '@/util/IPC'
   import { join } from '@/util/path-browserify'
@@ -38,19 +38,41 @@
     return file.value ? `${file.value}.default` : ''
   })
 
-  if (file.value) {
-    console.log('temporal-cli config file:', file.value)
-    fs.existsSync(file.value).then((e) => {
-      if (!e && currentVersion.value) {
-        IPC.send(
-          'app-fork:temporal-cli',
-          'initConfig',
-          JSON.parse(JSON.stringify(currentVersion.value))
-        ).then((key: string) => {
-          IPC.off(key)
-          conf?.value?.update()
-        })
-      }
+  const invokeTemporalCli = (...args: any[]) => {
+    return new Promise<any>((resolve) => {
+      IPC.send('app-fork:temporal-cli', ...args).then((key: string, res: any) => {
+        if (res?.code === 200) {
+          return
+        }
+        IPC.off(key)
+        resolve(res)
+      })
     })
   }
+
+  const ensureConfigFile = async () => {
+    if (!file.value || (await fs.existsSync(file.value))) {
+      return
+    }
+    if (!currentVersion.value) {
+      return
+    }
+    const res = await invokeTemporalCli(
+      'initConfig',
+      JSON.parse(JSON.stringify(currentVersion.value))
+    )
+    if (res?.code !== 0) {
+      return
+    }
+    await nextTick()
+    conf.value?.update()
+  }
+
+  watch(
+    file,
+    () => {
+      ensureConfigFile().catch()
+    },
+    { immediate: true }
+  )
 </script>

--- a/src/render/components/TemporalCli/Module.ts
+++ b/src/render/components/TemporalCli/Module.ts
@@ -5,7 +5,7 @@ const module: AppModuleItem = {
   moduleType: 'serviceGovernance',
   typeFlag: 'temporal-cli',
   label: 'Temporal CLI',
-  icon: import('@/svg/temporal.svg?raw'),
+  icon: import('@/svg/temporal-cli.svg?raw'),
   iconPadding: 5,
   index: defineAsyncComponent(() => import('./Index.vue')),
   aside: defineAsyncComponent(() => import('./aside.vue')),

--- a/src/render/components/TemporalCli/aside.vue
+++ b/src/render/components/TemporalCli/aside.vue
@@ -7,7 +7,7 @@
     <div class="left">
       <div class="icon-block" :class="{ run: serviceRunning }">
         <yb-icon
-          :svg="import('@/svg/temporal.svg?raw')"
+          :svg="import('@/svg/temporal-cli.svg?raw')"
           style="padding: 5px"
           width="28"
           height="28"


### PR DESCRIPTION
## Summary
- Fix TemporalCli config page init race when version loads asynchronously
- Fix IPC progress handling in Temporal/TemporalCli config pages
- Use dedicated temporal-cli.svg icon for Temporal CLI sidebar
- Expose all ClickHouse log files in log viewer

## Test plan
- [ ] Open Temporal CLI config tab, verify config initializes after version loads
- [ ] Open Temporal config tab, verify server/ui config files load correctly
- [ ] Verify Temporal CLI uses distinct icon from Temporal in sidebar
- [ ] Open ClickHouse log tab, verify all 6 log sources are switchable