### PR TITLE
Add MiniMax Hermes provider presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:clickhouse-ch-ui": "tsx scripts/clickhouse-ch-ui-test.ts",
     "test:clickhouse-service-lifecycle": "tsx scripts/clickhouse-service-lifecycle-test.ts",
     "test:go-gvm": "tsx scripts/go-gvm-test.ts",
+    "test:hermes-provider": "tsx scripts/hermes-provider-config-test.ts",
     "dev": "yarn run clean:dev && yarn run build-dev-runner && cross-env NODE_ENV=development node electron/dev-runner.mjs",
     "build": "yarn run clean:dev && yarn run clean && cross-env NODE_ENV=production npx esbuild --platform=node --bundle --packages=external --inject:scripts/shim-dynamic-require.mjs --format=esm scripts/app-builder.ts --outfile=electron/app-builder.mjs && cross-env NODE_ENV=production node electron/app-builder.mjs",
     "test:helper:contract": "tsx scripts/helper-contract-check.ts",

--- a/scripts/hermes-provider-config-test.ts
+++ b/scripts/hermes-provider-config-test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { HermesProviders } from '../src/render/components/Hermes/providers'
+
+const provider = HermesProviders.find((item) => item.name === 'MiniMax')
+
+assert.ok(provider, 'MiniMax should be available in the Hermes provider registry')
+assert.equal(provider.baseUrl, 'https://api.minimax.io/v1')
+assert.deepEqual(provider.models, ['MiniMax-M3', 'MiniMax-M2.7'])
+assert.deepEqual(provider.endpoints, [
+  {
+    region: 'global_en',
+    protocol: 'openai',
+    baseUrl: 'https://api.minimax.io/v1'
+  },
+  {
+    region: 'global_en',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.minimax.io/anthropic'
+  },
+  {
+    region: 'cn_zh',
+    protocol: 'openai',
+    baseUrl: 'https://api.minimaxi.com/v1'
+  },
+  {
+    region: 'cn_zh',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.minimaxi.com/anthropic'
+  }
+])
+
+console.log('hermes-provider-config-test: ok')

--- a/src/render/components/Hermes/providers.ts
+++ b/src/render/components/Hermes/providers.ts
@@ -1,0 +1,48 @@
+export type ProviderProtocol = 'openai' | 'anthropic'
+export type ProviderRegion = 'global_en' | 'cn_zh'
+
+export interface ProviderEndpoint {
+  region: ProviderRegion
+  protocol: ProviderProtocol
+  baseUrl: string
+}
+
+export interface ProviderItem {
+  name: string
+  baseUrl: string
+  models?: string[]
+  endpoints?: ProviderEndpoint[]
+}
+
+export const HermesProviders: ProviderItem[] = [
+  { name: 'Ollama', baseUrl: 'http://localhost:11434/v1' },
+  { name: 'OpenRouter', baseUrl: 'https://openrouter.ai/api/v1' },
+  { name: 'Anthropic', baseUrl: 'https://api.anthropic.com' },
+  {
+    name: 'MiniMax',
+    baseUrl: 'https://api.minimax.io/v1',
+    models: ['MiniMax-M3', 'MiniMax-M2.7'],
+    endpoints: [
+      {
+        region: 'global_en',
+        protocol: 'openai',
+        baseUrl: 'https://api.minimax.io/v1'
+      },
+      {
+        region: 'global_en',
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimax.io/anthropic'
+      },
+      {
+        region: 'cn_zh',
+        protocol: 'openai',
+        baseUrl: 'https://api.minimaxi.com/v1'
+      },
+      {
+        region: 'cn_zh',
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimaxi.com/anthropic'
+      }
+    ]
+  }
+]

--- a/src/render/components/Hermes/setup.ts
+++ b/src/render/components/Hermes/setup.ts
@@ -8,6 +8,9 @@ import { MessageError, MessageSuccess } from '@/util/Element'
 import { I18nT } from '@lang/index'
 import { getHermesInstallCommandLines, resolveHermesInstallPlatform } from './install'
 import CommandData from './command.json'
+import { HermesProviders, type ProviderItem } from './providers'
+
+export type { ProviderItem } from './providers'
 
 let SkillInspectVM: any
 
@@ -25,11 +28,6 @@ export interface CommandCategory {
 
 export interface CommandDataType {
   categories: CommandCategory[]
-}
-
-export interface ProviderItem {
-  name: string
-  baseUrl: string
 }
 
 export interface SessionItem {
@@ -102,11 +100,7 @@ class Hermes {
   configPaths: Record<string, string> = {}
   skills: string[] = []
   sessions: SessionItem[] = []
-  providers: ProviderItem[] = [
-    { name: 'Ollama', baseUrl: 'http://localhost:11434/v1' },
-    { name: 'OpenRouter', baseUrl: 'https://openrouter.ai/api/v1' },
-    { name: 'Anthropic', baseUrl: 'https://api.anthropic.com' }
-  ]
+  providers: ProviderItem[] = HermesProviders
   currentProvider = ''
   chatQuery = ''
   commandData: CommandDataType = CommandData as CommandDataType


### PR DESCRIPTION
Reason: Add MiniMax presets to the Hermes provider registry.

## Changes

- Add MiniMax-M3 and MiniMax-M2.7 model options.
- Add global and China endpoint presets for both supported API protocols.
- Add a focused provider registry test.

## Checks

- `yarn test:hermes-provider`
- `yarn tsx scripts/hermes-install-command-test.ts`
- `yarn prettier --check package.json src/render/components/Hermes/providers.ts src/render/components/Hermes/setup.ts scripts/hermes-provider-config-test.ts`
- `yarn eslint src/render/components/Hermes/providers.ts src/render/components/Hermes/setup.ts scripts/hermes-provider-config-test.ts`
- `yarn tsc --noEmit --pretty false --target ESNext --module ESNext --moduleResolution Bundler --strict --skipLibCheck --types node src/render/components/Hermes/providers.ts scripts/hermes-provider-config-test.ts`
- `yarn esbuild src/render/components/Hermes/setup.ts --bundle --platform=browser --format=esm --packages=external '--external:@/*' '--external:@lang/*' '--external:*.vue' --outfile=/tmp/flyenv-hermes-setup.mjs --log-level=error`
- `git diff --check`
- Secret scan passed.

The full project typecheck was also run and continues to report pre-existing errors outside the changed files.
