### PR TITLE
fix: localize About panel text for non-zh/en locales

### DIFF
--- a/src/lang/en/feedback.json
+++ b/src/lang/en/feedback.json
@@ -6,5 +6,11 @@
   "sendMessage": "Send Message",
   "anythingToSay": "Anything to say",
   "noSelected": "No Selected",
-  "inputFilter": "Input To Filter"
+  "inputFilter": "Input To Filter",
+  "about": {
+    "thanks": "Thanks for using FlyEnv. If you have any questions or suggestions, you can join the community for discussion. You can also submit GitHub Issues",
+    "starSponsor": "If FlyEnv is helpful to you, please star and sponsor for the project. Thanks",
+    "github": "GitHub:",
+    "sponsor": "Sponsor:"
+  }
 }

--- a/src/lang/zh/feedback.json
+++ b/src/lang/zh/feedback.json
@@ -6,5 +6,11 @@
   "sendMessage": "给我留言",
   "anythingToSay": "任何想说的",
   "noSelected": "未选择",
-  "inputFilter": "输入内容进行筛选"
+  "inputFilter": "输入内容进行筛选",
+  "about": {
+    "thanks": "感谢使用FlyEnv. 使用中的任何问题和建议. 都可以加入社群进行讨论. 也可以提交 GitHub Issues",
+    "starSponsor": "如果FlyEnv有帮助到你. 为了项目更好的发展, 烦请star和赞助. 感谢",
+    "github": "GitHub:",
+    "sponsor": "赞助:"
+  }
 }

--- a/src/render/components/About/index.vue
+++ b/src/render/components/About/index.vue
@@ -20,71 +20,36 @@
           </a>
         </div>
       </div>
-      <template v-if="lang === 'zh'">
-        <el-row style="padding: 0 20px; margin-top: 30px">
-          <el-col>
-            感谢使用FlyEnv. 使用中的任何问题和建议. 都可以加入社群进行讨论. 也可以提交 GitHub Issues
-          </el-col>
-          <el-col style="margin-top: 12px">
-            如果FlyEnv有帮助到你. 为了项目更好的发展, 烦请star和赞助. 感谢
-          </el-col>
-          <el-col style="margin-top: 12px">
-            GitHub:
-            <a
-              target="_blank"
-              href="javascript:"
-              rel="noopener noreferrer"
-              @click="openUrl($event, 'https://github.com/xpf0000/FlyEnv')"
-            >
-              https://github.com/xpf0000/FlyEnv
-            </a>
-          </el-col>
-          <el-col style="margin-top: 12px">
-            赞助:
-            <a
-              target="_blank"
-              href="javascript:"
-              rel="noopener noreferrer"
-              @click="openUrl($event, 'https://flyenv.com/license.html')"
-            >
-              https://flyenv.com/license.html
-            </a>
-          </el-col>
-        </el-row>
-      </template>
-      <template v-else>
-        <el-row style="padding: 0 20px; margin-top: 30px">
-          <el-col>
-            Thanks for using FlyEnv. If you have any questions or suggestions, you can join the
-            community for discussion. You can also submit GitHub Issues
-          </el-col>
-          <el-col style="margin-top: 12px">
-            If FlyEnv is helpful to you, please star and sponsor for the project. Thanks
-          </el-col>
-          <el-col style="margin-top: 12px">
-            GitHub:
-            <a
-              target="_blank"
-              href="javascript:"
-              rel="noopener noreferrer"
-              @click="openUrl($event, 'https://github.com/xpf0000/FlyEnv')"
-            >
-              https://github.com/xpf0000/FlyEnv
-            </a>
-          </el-col>
-          <el-col style="margin-top: 12px">
-            Sponsor:
-            <a
-              target="_blank"
-              href="javascript:"
-              rel="noopener noreferrer"
-              @click="openUrl($event, 'https://flyenv.com/license.html')"
-            >
-              https://flyenv.com/license.html
-            </a>
-          </el-col>
-        </el-row>
-      </template>
+      <el-row style="padding: 0 20px; margin-top: 30px">
+        <el-col>
+          {{ $t('feedback.about.thanks') }}
+        </el-col>
+        <el-col style="margin-top: 12px">
+          {{ $t('feedback.about.starSponsor') }}
+        </el-col>
+        <el-col style="margin-top: 12px">
+          {{ $t('feedback.about.github') }}
+          <a
+            target="_blank"
+            href="javascript:"
+            rel="noopener noreferrer"
+            @click="openUrl($event, 'https://github.com/xpf0000/FlyEnv')"
+          >
+            https://github.com/xpf0000/FlyEnv
+          </a>
+        </el-col>
+        <el-col style="margin-top: 12px">
+          {{ $t('feedback.about.sponsor') }}
+          <a
+            target="_blank"
+            href="javascript:"
+            rel="noopener noreferrer"
+            @click="openUrl($event, 'https://flyenv.com/license.html')"
+          >
+            https://flyenv.com/license.html
+          </a>
+        </el-col>
+      </el-row>
       <div style="margin: 20px 20px 0">
         <span style="margin-right: 12px">{{ $t('feedback.anythingToSay') }}</span>
         <el-button type="primary" @click.stop="toFeedback">{{
@@ -96,7 +61,7 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, computed, onMounted, onUnmounted } from 'vue'
+  import { ref, onMounted, onUnmounted } from 'vue'
   import { AppStore } from '@/store/app'
   import { AsyncComponentShow } from '@/util/AsyncComponent'
   import { app, shell } from '@/util/NodeFn'
@@ -105,8 +70,6 @@
 
   const version = ref('')
   const appStore = AppStore()
-
-  const lang = computed(() => appStore.config.setup.lang)
 
   const openUrl = (e: Event, url: string) => {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- The About panel's middle text block (thanks/star/GitHub/sponsor lines) was hardcoded with `v-if="lang === 'zh'"` / `v-else`, bypassing the i18n system the rest of the page uses (`$t()` / `I18nT()`).
- Any locale other than `zh` fell through to the hardcoded English branch, producing a mixed-language UI — e.g. a German user sees German everywhere except this block, which stays English.
- Moves the four strings into `feedback.json` (`en`/`zh`) under a new `about` key and renders them via `$t('feedback.about.*')`, consistent with the rest of the panel. Other locales will pick up translations the same way they already do for the rest of the app (falling back to English until translated).

Fixes #821

## Test plan
- [x] Verified `en/feedback.json` and `zh/feedback.json` parse as valid JSON with matching key sets under `about`
- [x] Confirmed nested dot-path key access (`namespace.group.key`) is an existing pattern in this codebase (e.g. `setup.module.path`)
- [ ] Maintainer to confirm in a running build that the About panel renders identically to before for `zh`/`en`, and now shows through i18n for other locales