### PR TITLE
Add tooltips for optional service modules

### DIFF
--- a/src/lang/en/setup.json
+++ b/src/lang/en/setup.json
@@ -39,6 +39,13 @@
     "licenseTips": "No license found. Only 3 modules/execution items can be created.",
     "outputLog": "Output Log"
   },
+  "moduleDescription": {
+    "consul": "Service discovery and configuration for distributed applications.",
+    "etcd": "Distributed key-value store for service configuration and state.",
+    "rnacos": "Service discovery and centralized configuration management.",
+    "temporal": "Reliable orchestration of application workflows and long-running processes.",
+    "temporalCli": "Command-line tool for managing and interacting with Temporal."
+  },
   "flyenvHelper": "Fix FlyEnv Helper",
   "flyenvHelperBtn": "Fix",
   "flyenvHelperFixSuccess": "FlyEnv Helper Fixed Successfully",

--- a/src/lang/fr/aside.json
+++ b/src/lang/fr/aside.json
@@ -14,8 +14,8 @@
   "appExit": "Arrêter tous les services démarrés et quitter FlyEnv",
   "groupStart": "Démarrer en un clic tous les services disponibles affichés sur le panneau",
   "networkTunnel": "Tunnel réseau",
-  "cacheAndQueue": "File d'attente du cache et des messages",
-  "serviceGovernance": "Gouvernance des services",
+  "cacheAndQueue": "Cache et files d'attente de messages",
+  "serviceGovernance": "Gestion des services distribués",
   "other": "Autres",
   "console": "Console"
 }

--- a/src/lang/fr/setup.json
+++ b/src/lang/fr/setup.json
@@ -39,6 +39,13 @@
     "licenseTips": "Aucune licence trouvée. Seuls 3 modules/éléments d'exécution peuvent être créés.",
     "outputLog": "Journal de sortie"
   },
+  "moduleDescription": {
+    "consul": "Découverte et configuration de services pour les architectures distribuées.",
+    "etcd": "Stockage clé-valeur distribué pour la configuration et l’état des systèmes distribués.",
+    "rnacos": "Découverte de services et gestion centralisée de leur configuration.",
+    "temporal": "Orchestration fiable de workflows et de processus applicatifs de longue durée.",
+    "temporalCli": "Outil en ligne de commande pour administrer et interagir avec Temporal."
+  },
   "flyenvHelper": "Réparer l'application d'assistance FlyEnv",
   "flyenvHelperBtn": "Réparer",
   "flyenvHelperFixSuccess": "Réparation de l'application d'assistance FlyEnv réussie",

--- a/src/render/components/Setup/ModuleShowHide/index.vue
+++ b/src/render/components/Setup/ModuleShowHide/index.vue
@@ -3,7 +3,16 @@
     class="relative flex justify-center items-center py-5 bg-[#33445526] w-full rounded-md dark:bg-[#32364A]"
   >
     <div class="flex items-center">
-      <div class="w-[130px] truncate">{{ title }}</div>
+      <div class="w-[130px] flex items-center gap-1">
+        <div class="truncate">{{ title }}</div>
+        <el-tooltip
+          v-if="description"
+          :content="description"
+          placement="top"
+        >
+          <InfoFilled class="w-[14px] h-[14px] shrink-0 cursor-help text-zinc-400" />
+        </el-tooltip>
+      </div>
       <el-switch v-model="showItem" :loading="changing" :disabled="changing" />
     </div>
     <slot name="default"></slot>
@@ -16,6 +25,8 @@
   import { AppCustomerModule } from '@/core/Module'
   import { canSetModuleVisibility } from '@/core/ModuleVisibility'
   import type { AllAppModule } from '@/core/type'
+  import { InfoFilled } from '@element-plus/icons-vue'
+  import { I18nT } from '@lang/index'
 
   type StringFn = () => string
 
@@ -29,6 +40,19 @@
       return props.label
     }
     return props.label?.() ?? ''
+  })
+
+  const descriptionKeys: Record<string, string> = {
+    consul: 'setup.moduleDescription.consul',
+    etcd: 'setup.moduleDescription.etcd',
+    rnacos: 'setup.moduleDescription.rnacos',
+    temporal: 'setup.moduleDescription.temporal',
+    'temporal-cli': 'setup.moduleDescription.temporalCli'
+  }
+
+  const description = computed(() => {
+    const key = descriptionKeys[props.typeFlag]
+    return key ? I18nT(key) : ''
   })
 
   const appStore = AppStore()


### PR DESCRIPTION
Adds concise tooltips to optional service modules in Settings, helping users understand the purpose of services such as Consul, etcd, R-Nacos, and Temporal before enabling them in the sidebar.

Also improves the French translations for the related module categories.