### PR TITLE
Fix node-window-manager build on Visual Studio 2026

### DIFF
--- a/patches/@xpf0000+node-window-manager+0.0.16.patch
+++ b/patches/@xpf0000+node-window-manager+0.0.16.patch
@@ -2,7 +2,17 @@ diff --git a/node_modules/@xpf0000/node-window-manager/binding.gyp b/node_module
 index 666f0d3..7dff8c8 100644
 --- a/node_modules/@xpf0000/node-window-manager/binding.gyp
 +++ b/node_modules/@xpf0000/node-window-manager/binding.gyp
-@@ -31,7 +31,8 @@
+@@ -18,7 +18,8 @@
+             "d3d11.lib",
+             "dxgi.lib",
+             "windowscodecs.lib",
+-            "shcore.lib"
++            "shcore.lib",
++            "windowsapp.lib"
+           ],
+             "defines": [
+               "WIN32_LEAN_AND_MEAN",
+@@ -31,7 +32,8 @@
                    "ExceptionHandling": 1,
                    "AdditionalOptions": [
                       "/std:c++20",


### PR DESCRIPTION
Fixes a Windows build failure of @xpf0000/node-window-manager when building FlyEnv with Visual Studio 2026.

The linker failed with the following unresolved WinRT symbols:

WINRT_IMPL_RoOriginateLanguageException
WINRT_IMPL_RoGetActivationFactory

Adding windowsapp.lib to the Windows libraries in the existing patch-package patch resolves the linker errors.

Tested successfully with:

Windows 11 x64
Visual Studio 2026 18.9
MSVC v14.50 / 14.51
Node.js 22.23.2
node-gyp 13.0.0
Electron 39.8.10

After applying the patch, electron-builder install-app-deps successfully rebuilds @xpf0000/node-window-manager, dtrace-provider, and node-pty.