### PR TITLE
fix: preserve hidden files when creating Laravel projects

### DIFF
--- a/src/render/components/Host/CreateProject/phpCreate.vue
+++ b/src/render/components/Host/CreateProject/phpCreate.vue
@@ -258,7 +258,9 @@
         )
       }
       command.push(`cd flyenv-created-project`)
-      command.push(`mv ./* ../`)
+      command.push(
+        `find . -mindepth 1 -maxdepth 1 -exec sh -c 'for item; do mv -- "$item" ../ || exit 1; done' sh {} +`
+      )
       command.push(`cd ../`)
       command.push(`rm -rf flyenv-created-project`)
     }


### PR DESCRIPTION
## Problem

When creating a Laravel project from PHP > New Project, FlyEnv moves the
generated files using `mv ./* ../`.

The `*` glob does not match hidden files or directories, so files such as
`.env`, `.gitignore`, `.gitattributes`, and `.editorconfig` are left in the
temporary directory and deleted during cleanup.

## Fix

Use `find` to move every direct child, including hidden files and directories.

The move command now propagates failures, preventing the temporary directory
from being removed if any item cannot be moved.

## Verification

Manually created a Laravel project on macOS and confirmed that its hidden
files are preserved.

Other PHP frameworks were not manually tested.