### PR TITLE
fix: distinguish Homebrew PHP formula sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "test:hosts-idempotent-write": "tsx scripts/hosts-idempotent-write-test.ts",
     "test:stop-process-list-cache": "tsx scripts/stop-process-list-cache-test.ts",
     "test:bin-version-cache": "tsx scripts/bin-version-cache-test.ts",
+    "test:brew-formula-tap-installed": "tsx scripts/brew-formula-tap-installed-test.ts",
+    "test:brew-formula-conflict": "tsx scripts/brew-formula-conflict-test.ts",
     "test:rabbitmq-enumeration-timeout": "tsx scripts/rabbitmq-enumeration-timeout-test.ts",
     "test:env-sync-coordinator": "tsx scripts/env-sync-coordinator-test.ts",
     "test:fork-idle-lifecycle": "tsx scripts/fork-idle-lifecycle-test.ts",

--- a/scripts/brew-formula-conflict-test.ts
+++ b/scripts/brew-formula-conflict-test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+
+import {
+  brewFormulaSourceName,
+  findInstalledFormulaConflict
+} from '../src/render/components/VersionManager/brew/FormulaConflict'
+
+assert.equal(brewFormulaSourceName('php'), 'Homebrew Core')
+assert.equal(brewFormulaSourceName('php@8.4'), 'Homebrew Core')
+assert.equal(brewFormulaSourceName('homebrew/core/php@8.4'), 'Homebrew Core')
+assert.equal(brewFormulaSourceName('shivammathur/php/php@8.4'), 'shivammathur/php')
+
+const core84 = { name: 'php@8.4', installed: false }
+const tap84 = { name: 'shivammathur/php/php@8.4', installed: true }
+const core83 = { name: 'php@8.3', installed: true }
+
+assert.equal(findInstalledFormulaConflict(core84, [core84, tap84, core83]), tap84.name)
+assert.equal(
+  findInstalledFormulaConflict({ name: 'shivammathur/php/php@8.4', installed: false }, [
+    { name: 'php@8.4', installed: true }
+  ]),
+  'php@8.4'
+)
+assert.equal(findInstalledFormulaConflict(core83, [core83, tap84]), undefined)
+assert.equal(
+  findInstalledFormulaConflict({ name: 'php@8.3', installed: false }, [tap84]),
+  undefined
+)
+assert.equal(
+  findInstalledFormulaConflict({ name: 'shivammathur/php/php', installed: false }, [
+    { name: 'php', installed: true }
+  ]),
+  'php'
+)
+const onlyLegacySource = { name: 'shivammathur/php/php@7.4', installed: false }
+assert.equal(findInstalledFormulaConflict(onlyLegacySource, [onlyLegacySource]), undefined)
+
+console.log('brew formula conflict tests passed')

--- a/scripts/brew-formula-tap-installed-test.ts
+++ b/scripts/brew-formula-tap-installed-test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  brewFormulaInstalledForTap,
+  qualifyHomebrewCoreFormula
+} from '../src/fork/util/BrewFormula'
+
+assert.equal(qualifyHomebrewCoreFormula('php'), 'homebrew/core/php')
+assert.equal(qualifyHomebrewCoreFormula('php@8.4'), 'homebrew/core/php@8.4')
+assert.equal(qualifyHomebrewCoreFormula('shivammathur/php/php@8.4'), 'shivammathur/php/php@8.4')
+
+const tempRoot = await mkdtemp(join(tmpdir(), 'flyenv-brew-formula-tap-'))
+const cellarDir = join(tempRoot, 'Cellar')
+const receiptDir = join(cellarDir, 'php@8.4', '8.4.25')
+
+try {
+  await mkdir(receiptDir, { recursive: true })
+  await writeFile(
+    join(receiptDir, 'INSTALL_RECEIPT.json'),
+    JSON.stringify({ source: { tap: 'shivammathur/php' } }),
+    'utf8'
+  )
+
+  const installed = [{ version: '8.4.25' }]
+  assert.equal(
+    await brewFormulaInstalledForTap({ name: 'php@8.4', tap: 'homebrew/core', installed }, [
+      cellarDir
+    ]),
+    false
+  )
+  assert.equal(
+    await brewFormulaInstalledForTap({ name: 'php@8.4', tap: 'shivammathur/php', installed }, [
+      cellarDir
+    ]),
+    true
+  )
+  assert.equal(
+    await brewFormulaInstalledForTap({ name: 'php@8.4', tap: 'shivammathur/php', installed: [] }, [
+      cellarDir
+    ]),
+    false
+  )
+
+  const olderReceiptDir = join(cellarDir, 'php@8.4', '8.4.24')
+  await mkdir(olderReceiptDir, { recursive: true })
+  await writeFile(
+    join(olderReceiptDir, 'INSTALL_RECEIPT.json'),
+    JSON.stringify({ source: { tap: 'homebrew/core' } }),
+    'utf8'
+  )
+  const multipleInstalledVersions = [{ version: '8.4.24' }, { version: '8.4.25' }]
+  assert.equal(
+    await brewFormulaInstalledForTap(
+      { name: 'php@8.4', tap: 'homebrew/core', installed: multipleInstalledVersions },
+      [cellarDir]
+    ),
+    true
+  )
+  assert.equal(
+    await brewFormulaInstalledForTap(
+      { name: 'php@8.4', tap: 'shivammathur/php', installed: multipleInstalledVersions },
+      [cellarDir]
+    ),
+    true
+  )
+
+  await writeFile(join(receiptDir, 'INSTALL_RECEIPT.json'), '{invalid json', 'utf8')
+  const originalWarn = console.warn
+  console.warn = () => {}
+  try {
+    assert.equal(
+      await brewFormulaInstalledForTap({ name: 'php@8.4', tap: 'homebrew/core', installed }, [
+        cellarDir
+      ]),
+      true,
+      'invalid legacy receipts preserve Homebrew JSON behavior'
+    )
+  } finally {
+    console.warn = originalWarn
+  }
+
+  console.log('brew formula tap installed tests passed')
+} finally {
+  await rm(tempRoot, { force: true, recursive: true })
+}

--- a/scripts/brew-info-json-fallback-test.ts
+++ b/scripts/brew-info-json-fallback-test.ts
@@ -21,6 +21,11 @@ if [ "$1" != "info" ]; then
   exit 2
 fi
 
+if [ "$2" = "homebrew/core/php@8.5" ]; then
+  printf '[{"name":"php","full_name":"php","tap":"homebrew/core","versions":{"stable":"8.5.9"},"installed":[]},{"name":"php","full_name":"php","tap":"homebrew/core","versions":{"stable":"8.5.9"},"installed":[]},{"name":"php","full_name":"shivammathur/php/php","tap":"shivammathur/php","versions":{"stable":"8.5.10"},"installed":[]}]'
+  exit 0
+fi
+
 if [ "$2" = "mongodb/brew/mongodb-community" ] && [ "$3" = "--json" ]; then
   printf '[{"versions":{"stable":"8.0.12"},"installed":[],"full_name":"mongodb/brew/mongodb-community"}]'
   exit 0
@@ -40,6 +45,21 @@ exit 1
     ...process.env,
     PATH: tempDir
   }
+
+  const phpInfo = await brewInfoJson(
+    ['homebrew/core/php@8.5', 'shivammathur/php/php@8.5', 'shivammathur/php/php'],
+    { tapAware: true }
+  )
+
+  assert.deepEqual(phpInfo, [
+    { version: '8.5.9', installed: false, name: 'php', flag: 'brew' },
+    {
+      version: '8.5.10',
+      installed: false,
+      name: 'shivammathur/php/php',
+      flag: 'brew'
+    }
+  ])
 
   const info = await brewInfoJson([
     'mongodb/brew/mongodb-community',

--- a/src/fork/module/Php/index.ts
+++ b/src/fork/module/Php/index.ts
@@ -38,6 +38,7 @@ import { unpack } from '../../util/Zip'
 import { parse as iniParse } from 'ini'
 import { IniParse } from '../../../render/util/IniParse'
 import { uuid } from '@shared/utils'
+import { qualifyHomebrewCoreFormula } from '../../util/BrewFormula'
 
 class Php extends Base {
   constructor() {
@@ -616,10 +617,11 @@ xdebug.output_dir = "${output_dir}"
   brewinfo() {
     return new ForkPromise(async (resolve, reject) => {
       try {
-        let all: Array<string> = ['php']
+        let all: Array<string> = ['php', 'shivammathur/php/php']
         const command = 'brew search -q --formula "/^(php|shivammathur/php/php)@[\\d\\.]+$/"'
         all = await brewSearch(all, command)
-        const info = await brewInfoJson(all)
+        all = [...new Set(all.map(qualifyHomebrewCoreFormula))]
+        const info = await brewInfoJson(all, { tapAware: true })
         resolve(info)
       } catch (e) {
         reject(e)

--- a/src/fork/util/BrewFormula.ts
+++ b/src/fork/util/BrewFormula.ts
@@ -1,0 +1,62 @@
+import { existsSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+type BrewFormulaInfo = {
+  name?: string
+  tap?: string
+  installed?: Array<{ version?: string }>
+}
+
+type BrewInstallReceipt = {
+  source?: {
+    tap?: string
+  }
+}
+
+export const qualifyHomebrewCoreFormula = (name: string) => {
+  const formula = name.trim()
+  return formula.includes('/') ? formula : `homebrew/core/${formula}`
+}
+
+export const brewFormulaInstalledForTap = async (item: BrewFormulaInfo, cellarDirs: string[]) => {
+  const installed = Array.isArray(item.installed) ? item.installed : []
+  if (installed.length === 0) {
+    return false
+  }
+
+  const formulaName = `${item.name ?? ''}`.trim()
+  const formulaTap = `${item.tap ?? ''}`.trim()
+  if (!formulaName || !formulaTap) {
+    return true
+  }
+
+  let foundTapIdentity = false
+  for (const install of installed) {
+    const version = `${install?.version ?? ''}`.trim()
+    if (!version) {
+      continue
+    }
+    for (const cellarDir of cellarDirs) {
+      const receiptFile = join(cellarDir, formulaName, version, 'INSTALL_RECEIPT.json')
+      if (!existsSync(receiptFile)) {
+        continue
+      }
+      try {
+        const receipt = JSON.parse(await readFile(receiptFile, 'utf8')) as BrewInstallReceipt
+        const receiptTap = `${receipt?.source?.tap ?? ''}`.trim()
+        if (!receiptTap) {
+          continue
+        }
+        foundTapIdentity = true
+        if (receiptTap === formulaTap) {
+          return true
+        }
+      } catch (error) {
+        console.warn(`Unable to read Homebrew install receipt ${receiptFile}: `, error)
+      }
+    }
+  }
+
+  return !foundTapIdentity
+}

--- a/src/fork/util/Version.ts
+++ b/src/fork/util/Version.ts
@@ -15,6 +15,7 @@ import * as process from 'node:process'
 import { userInfo } from 'node:os'
 import { execSync } from 'node:child_process'
 import { withBinVersionCache } from './BinVersionCache'
+import { brewFormulaInstalledForTap } from './BrewFormula'
 
 const COMMAND_LOOKUP_TIMEOUT_MS = 60_000
 
@@ -334,6 +335,20 @@ const fetchBrewCellarDirs = async () => {
   return Array.from(dirs)
 }
 
+const fetchActiveBrewCellarDirs = async () => {
+  try {
+    const res = await spawnPromiseWithEnv('brew', ['--cellar'])
+    const dirs = res.stdout
+      .split('\n')
+      .map((dir) => normalizeExistingDir(dir))
+      .filter((dir): dir is string => !!dir)
+    if (dirs.length > 0) {
+      return [...new Set(dirs)]
+    }
+  } catch {}
+  return fetchBrewCellarDirs()
+}
+
 export const versionLocalFetch = async (
   customDirs: string[],
   binName: string,
@@ -507,24 +522,40 @@ export const versionMacportsFetch = async (bins: string[]): Promise<Array<SoftIn
   return list
 }
 
-export const brewInfoJson = async (names: string[]) => {
+export const brewInfoJson = async (names: string[], options?: { tapAware?: boolean }) => {
   const info: any = []
   if (!names.length) {
     return info
+  }
+  const fetchedFormulae = options?.tapAware ? new Set<string>() : undefined
+  let cellarDirs: string[] | undefined
+  const getCellarDirs = async () => {
+    cellarDirs ??= await fetchActiveBrewCellarDirs()
+    return cellarDirs
   }
   const fetchInfo = async (formulaNames: string[]) => {
     const command = ['brew', 'info', ...formulaNames, '--json', '--formula'].join(' ')
     console.log('brewinfo doRun: ', command)
     const res = await execPromiseWithEnv(command)
     const arr = JSON.parse(res.stdout)
-    arr.forEach((item: any) => {
+    for (const item of arr) {
+      const formulaKey = `${item?.tap ?? ''}:${item?.full_name ?? item?.name ?? ''}`
+      if (fetchedFormulae?.has(formulaKey)) {
+        continue
+      }
+      fetchedFormulae?.add(formulaKey)
+      const installed = item?.installed?.length
+        ? options?.tapAware
+          ? await brewFormulaInstalledForTap(item, await getCellarDirs())
+          : true
+        : false
       info.push({
         version: item?.versions?.stable ?? '',
-        installed: item?.installed?.length > 0,
+        installed,
         name: item.full_name,
         flag: 'brew'
       })
-    })
+    }
   }
   try {
     await fetchInfo(names)

--- a/src/lang/en/versionmanager.json
+++ b/src/lang/en/versionmanager.json
@@ -2,5 +2,7 @@
   "noBrewFound": "<a href=\"javascript:void();\" onclick=\"openUrl('https://brew.sh/')\">Homebrew</a> is not found\nTo install Homebrew, click the install button to proceed\nYou can also click on this link\n<a href=\"javascript:void();\" onclick=\"openUrl('https://flyenv.com/guide/getting-started.html#macos-1')\">https://flyenv.com/guide/getting-started.html#macos-1</a>\nFollow the documentation to install.",
   "noPortFound": "<a href=\"javascript:void();\" onclick=\"openUrl('https://www.macports.org/')\">Macports</a> is not found.\nInstall Macports, you can click on this link\n<a href=\"javascript:void();\" onclick=\"openUrl('https://www.macports.org/install.php')\">https://www.macports.org/install.php</a>\nFollow the documentation to install.",
   "brewErrorTips": "At this location {bin}, Homebrew executable files were detected.\nHowever, FlyEnv cannot call them. Error message:\n{error}",
-  "noSDKMANFound": "<a href=\"javascript:void();\" onclick=\"openUrl('https://sdkman.io/')\">SDKMAN</a> not found\nTo install SDKMAN, click the install button to proceed"
+  "noSDKMANFound": "<a href=\"javascript:void();\" onclick=\"openUrl('https://sdkman.io/')\">SDKMAN</a> not found\nTo install SDKMAN, click the install button to proceed",
+  "brewFormulaConflict": "Current source: {source}\nUninstall the current PHP version before switching sources.",
+  "brewFormulaUnavailable": "Unavailable"
 }

--- a/src/lang/zh/versionmanager.json
+++ b/src/lang/zh/versionmanager.json
@@ -2,5 +2,7 @@
   "noBrewFound": "未检测到 <a href=\"javascript:void();\" onclick=\"openUrl('https://brew.sh/')\">Homebrew</a>\n如需安装 Homebrew, 可点击安装按钮进行安装\n也可以点击此链接\n<a href=\"javascript:void();\" onclick=\"openUrl('https://flyenv.com/zh/guide/getting-started.html#macos-1')\">https://flyenv.com/zh/guide/getting-started.html#macos-1</a>\n按照文档说明自行安装. 使用国内链接安装时, 注意不要跳过Homebrew-Core. 需要完整安装",
   "noPortFound": "未检测到<a href=\"javascript:void();\" onclick=\"openUrl('https://www.macports.org/')\">Macports</a>\n如想安装 Macports, 可以点击此链接\n<a href=\"javascript:void();\" onclick=\"openUrl('https://www.macports.org/install.php')\">https://www.macports.org/install.php</a>\n按照文档说明进行安装.",
   "brewErrorTips": "在此位置{bin}, 检测到 Homebrew 的可执行文件. \n但是FlyEnv 无法调用. 错误信息: \n{error}",
-  "noSDKMANFound": "未检测到 <a href=\"javascript:void();\" onclick=\"openUrl('https://sdkman.io/')\">SDKMAN</a>\n如需安装 SDKMAN, 可点击安装按钮进行安装"
+  "noSDKMANFound": "未检测到 <a href=\"javascript:void();\" onclick=\"openUrl('https://sdkman.io/')\">SDKMAN</a>\n如需安装 SDKMAN, 可点击安装按钮进行安装",
+  "brewFormulaConflict": "当前来源：{source}\n切换来源前，请先卸载当前 PHP 版本。",
+  "brewFormulaUnavailable": "不可用"
 }

--- a/src/render/components/VersionManager/brew/FormulaConflict.ts
+++ b/src/render/components/VersionManager/brew/FormulaConflict.ts
@@ -1,0 +1,33 @@
+type BrewFormulaItem = {
+  name?: string
+  installed?: boolean
+}
+
+const formulaRackName = (name: string) => name.trim().split('/').pop() ?? ''
+
+export const brewFormulaSourceName = (name: string) => {
+  const parts = name.trim().split('/')
+  const tap = parts.length > 1 ? parts.slice(0, -1).join('/') : ''
+  return !tap || tap === 'homebrew/core' ? 'Homebrew Core' : tap
+}
+
+export const findInstalledFormulaConflict = (
+  item: BrewFormulaItem,
+  items: BrewFormulaItem[]
+): string | undefined => {
+  if (item.installed) {
+    return undefined
+  }
+
+  const rackName = formulaRackName(item.name ?? '')
+  if (!rackName) {
+    return undefined
+  }
+
+  return items.find(
+    (candidate) =>
+      candidate.installed &&
+      candidate.name !== item.name &&
+      formulaRackName(candidate.name ?? '') === rackName
+  )?.name
+}

--- a/src/render/components/VersionManager/brew/index.vue
+++ b/src/render/components/VersionManager/brew/index.vue
@@ -72,6 +72,17 @@
               :svg="import('@/svg/ok.svg?raw')"
               class="installed"
             ></yb-icon>
+            <el-tooltip
+              v-else-if="scope.row.conflictingFormula"
+              :content="formulaConflictTips(scope.row)"
+              placement="top"
+              popper-class="brew-formula-conflict-tooltip"
+            >
+              <span class="text-yellow-500 cursor-help inline-flex items-center gap-1">
+                {{ I18nT('versionmanager.brewFormulaUnavailable') }}
+                <yb-icon :svg="import('@/svg/question.svg?raw')" width="12" height="12"></yb-icon>
+              </span>
+            </el-tooltip>
           </div>
         </template>
       </el-table-column>
@@ -81,7 +92,7 @@
             type="primary"
             link
             :style="{ opacity: scope.row.version !== undefined ? 1 : 0 }"
-            :disabled="BrewSetup.installing"
+            :disabled="BrewSetup.installing || !!scope.row.conflictingFormula"
             @click="handleBrewVersion(scope.row)"
             >{{
               scope.row.installed ? I18nT('common.action.uninstall') : I18nT('base.install')
@@ -111,6 +122,7 @@
     installBrew,
     fetchCommand,
     copyCommand,
+    formulaConflictTips,
     showBrewError,
     brewError,
     brewBin
@@ -121,5 +133,13 @@
     a {
       color: #4096ff;
     }
+  }
+
+  .brew-formula-conflict-tooltip {
+    max-width: 245px;
+    font-size: 12px !important;
+    line-height: 18px;
+    white-space: pre-line;
+    overflow-wrap: anywhere;
   }
 </style>

--- a/src/render/components/VersionManager/brew/setup.ts
+++ b/src/render/components/VersionManager/brew/setup.ts
@@ -4,10 +4,11 @@ import { BrewStore } from '@/store/brew'
 import XTerm from '@/util/XTerm'
 import IPC from '@/util/IPC'
 import type { AllAppModule } from '@/core/type'
-import { MessageSuccess } from '@/util/Element'
+import { MessageSuccess, MessageWarning } from '@/util/Element'
 import { I18nT } from '@lang/index'
 import { join, basename, dirname } from '@/util/path-browserify'
 import { clipboard, fs } from '@/util/NodeFn'
+import { brewFormulaSourceName, findInstalledFormulaConflict } from './FormulaConflict'
 
 export const BrewSetup = reactive<{
   installEnd: boolean
@@ -163,6 +164,13 @@ export const Setup = (typeFlag: AllAppModule) => {
     return `brew ${fn} ${row.name}`
   }
 
+  const formulaConflictTips = (row: any) =>
+    row.conflictingFormula
+      ? I18nT('versionmanager.brewFormulaConflict', {
+          source: brewFormulaSourceName(row.conflictingFormula)
+        })
+      : ''
+
   const copyCommand = (row: any) => {
     const command = fetchCommand(row)
     clipboard.writeText(command)
@@ -171,6 +179,14 @@ export const Setup = (typeFlag: AllAppModule) => {
 
   const handleBrewVersion = async (row: any) => {
     if (BrewSetup.installing) {
+      return
+    }
+    if (row.conflictingFormula) {
+      MessageWarning(
+        I18nT('versionmanager.brewFormulaConflict', {
+          source: brewFormulaSourceName(row.conflictingFormula)
+        })
+      )
       return
     }
     BrewSetup.installing = true
@@ -223,12 +239,14 @@ export const Setup = (typeFlag: AllAppModule) => {
         return n
       })
       const num = parseInt(nums.join(''))
-      Object.assign(value, {
+      arr.push({
+        ...value,
         version: value.version,
         installed: value.installed,
+        conflictingFormula:
+          typeFlag === 'php' ? findInstalledFormulaConflict(value, list) : undefined,
         num
       })
-      arr.push(value)
     }
     arr.sort((a: any, b: any) => {
       return b.num - a.num
@@ -294,6 +312,7 @@ export const Setup = (typeFlag: AllAppModule) => {
     xtermDom,
     fetchCommand,
     copyCommand,
+    formulaConflictTips,
     showBrewError,
     brewBin,
     brewError


### PR DESCRIPTION
## Summary

Homebrew Core and `shivammathur/php` may provide PHP Formulae that share the same Cellar rack. Homebrew's JSON output can report both Formulae as installed even when only one Tap is the actual installation source.

This PR:

- queries the canonical PHP Formulae from both Homebrew Core and `shivammathur/php`
- distinguishes the installed source using `INSTALL_RECEIPT.json` and its `source.tap`
- deduplicates Formula aliases such as `php@8.5` that resolve to `php`
- marks another source using the same Cellar rack as unavailable
- displays the active Tap source in a tooltip
- keeps single-source legacy PHP versions available
- limits Tap-aware behavior to the PHP module so other Homebrew modules retain their existing behavior

## Testing

Manually verified:

- Homebrew Core PHP 8.5 installed:
  - `php` is shown as installed
  - `shivammathur/php/php` is shown as unavailable
- `shivammathur/php/php@8.4` installed:
  - the shivammathur Formula is shown as installed
  - `php@8.4` is shown as unavailable
- PHP versions with only one available source remain installable

Automated checks:

- Homebrew Tap receipt detection
- Formula alias deduplication and fallback behavior
- bidirectional Formula conflict detection
- single-source legacy version behavior
- renderer operation boundaries
- language resources and fallback
- ESLint and formatting checks

Fixes #837