### PR TITLE
完善 MySQL 多版本独立管理与端口冲突处理

### DIFF
--- a/.github/workflows/windows-test-build.yml
+++ b/.github/workflows/windows-test-build.yml
@@ -1,0 +1,68 @@
+name: Windows Test Build (unsigned)
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/mysql-multi-instance-port
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows-test:
+    name: Build Windows Test Packages (x64)
+    runs-on: windows-2022
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: choco install -y make
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'src/helper-go/go.mod'
+          cache-dependency-path: 'src/helper-go/go.sum'
+
+      - name: Install Yarn and build tools
+        run: npm install -g yarn node-gyp
+
+      - name: Install dependencies with Yarn
+        shell: pwsh
+        run: |
+          $env:LINK = 'runtimeobject.lib'
+          yarn install
+
+      - name: Build Go helper
+        shell: pwsh
+        run: |
+          go install github.com/tc-hib/go-winres@latest
+          $env:PATH = "$(go env GOPATH)\bin;$env:PATH"
+          Set-Location "$env:GITHUB_WORKSPACE/src/helper-go"
+          go mod download
+          go-winres make
+          .\build-win.ps1
+
+      - name: Build unsigned Windows packages
+        shell: pwsh
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: yarn build:win
+
+      - name: Upload Windows test artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: FlyEnv-Windows-x64-test-unsigned
+          path: |
+            release/*.exe
+          if-no-files-found: error
+          retention-days: 14

--- a/src/fork/module/Base/index.ts
+++ b/src/fork/module/Base/index.ts
@@ -83,7 +83,7 @@ export class Base {
     })
   }
 
-  protected appPidFile() {
+  protected appPidFile(_version?: SoftInstalled) {
     return join(global.Server.BaseDir!, `pid/${this.type}.pid`)
   }
 
@@ -202,8 +202,8 @@ export class Base {
     )
   }
 
-  protected async saveAppPid(pid: string | number) {
-    const appPidFile = this.appPidFile()
+  protected async saveAppPid(pid: string | number, version?: SoftInstalled) {
+    const appPidFile = this.appPidFile(version)
     await this.ensureAppPidDirWritable()
     await remove(appPidFile).catch(() => {})
     await writeFile(appPidFile, `${pid}`.trim())
@@ -251,7 +251,7 @@ export class Base {
       try {
         if (res?.['APP-Service-Start-PID']) {
           const pid = res['APP-Service-Start-PID']
-          await this.saveAppPid(pid)
+          await this.saveAppPid(pid, version)
         }
       } catch (e) {
         console.error('save app pid error: ', e)
@@ -279,7 +279,7 @@ export class Base {
       on({
         'APP-Service-Stop-Success': true
       })
-      const appPidFile = this.appPidFile()
+      const appPidFile = this.appPidFile(version)
       const ownedMarkers = this.ownedProcessMarkers(version)
       try {
         const appPid = await this.readPidFromFile(appPidFile)

--- a/src/fork/module/Mysql/index.ts
+++ b/src/fork/module/Mysql/index.ts
@@ -30,7 +30,16 @@ import { ForkPromise } from '@shared/ForkPromise'
 import TaskQueue from '../../TaskQueue'
 import Helper from '../../Helper'
 import { isWindows, pathFixedToUnix } from '@shared/utils'
-import { PItem, ProcessKill, ProcessOwnedPidsByPid } from '@shared/Process'
+import {
+  fetchProcessPidByPort as fetchUnixProcessPidByPort,
+  PItem,
+  ProcessKill,
+  ProcessOwnedPidsByPid
+} from '@shared/Process'
+import {
+  fetchProcessPidByPort as fetchWindowsProcessPidByPort,
+  ProcessPidListStrict
+} from '@shared/Process.win'
 import { StopProcessListSearch, StopProcessPidList } from '@shared/StopProcessList'
 import { EOL } from 'os'
 import { createConnection } from 'mysql2/promise'
@@ -47,19 +56,38 @@ class Mysql extends Base {
   }
 
   init() {
-    this.pidPath = join(global.Server.MysqlDir!, 'mysql.pid')
+    // MySQL is version-scoped; runtime paths are resolved from the version object.
+  }
+
+  private runtimePaths(version: SoftInstalled) {
+    const v = version?.version?.split('.')?.slice(0, 2)?.join('.') ?? 'default'
+    const base = global.Server.MysqlDir!
+    return {
+      config: join(base, `my-${v}.cnf`),
+      dataDir: join(base, `data-${v}`),
+      pid: join(base, `mysql-${v}.pid`),
+      slowLog: join(base, `mysql-${v}-slow.log`),
+      errorLog: join(base, `mysql-${v}-error.log`),
+      socket: join(base, `mysql-${v}.sock`)
+    }
+  }
+
+  protected appPidFile(version?: SoftInstalled) {
+    const v = version?.version?.split('.')?.slice(0, 2)?.join('.') ?? 'default'
+    return join(global.Server.MysqlDir!, `mysql-${v}.app.pid`)
   }
 
   getConfigFiles(version?: SoftInstalled) {
-    const v = version?.version?.split('.')?.slice(0, 2)?.join('.') ?? ''
-    if (!v) return []
-    return [{ name: 'main', path: join(global.Server.MysqlDir!, `my-${v}.cnf`) }]
+    if (!version?.version) return []
+    return [{ name: 'main', path: this.runtimePaths(version).config }]
   }
 
-  getLogFiles() {
+  getLogFiles(version?: SoftInstalled) {
+    if (!version?.version) return []
+    const paths = this.runtimePaths(version)
     return [
-      { name: 'error', path: join(global.Server.MysqlDir!, 'error.log') },
-      { name: 'slow', path: join(global.Server.MysqlDir!, 'slow.log') }
+      { name: 'error', path: paths.errorLog },
+      { name: 'slow', path: paths.slowLog }
     ]
   }
 
@@ -74,7 +102,12 @@ class Mysql extends Base {
         if (existsSync(bin)) {
           process.chdir(dirname(bin))
           try {
-            await execPromise(`mysqladmin.exe --host="127.0.0.1" -uroot password "${password}"`)
+            const port =
+              iniParse(await readFile(this.runtimePaths(version).config, 'utf8'))?.mysqld?.port ??
+              3306
+            await execPromise(
+              `mysqladmin.exe --host="127.0.0.1" --port=${port} -uroot password "${password}"`
+            )
           } catch (e) {
             on({
               'APP-On-Log': AppLog('error', I18nT('appLog.initDBPassFail', { error: e }))
@@ -99,9 +132,12 @@ class Mysql extends Base {
         }
         resolve(true)
       } else {
-        execPromise(`./mysqladmin --socket=/tmp/mysql.sock -uroot password "${password}"`, {
-          cwd: dirname(version.bin)
-        })
+        execPromise(
+          `./mysqladmin --socket="${this.runtimePaths(version).socket}" -uroot password "${password}"`,
+          {
+            cwd: dirname(version.bin)
+          }
+        )
           .then((res) => {
             on({
               'APP-On-Log': AppLog(
@@ -124,14 +160,11 @@ class Mysql extends Base {
   }
 
   _stopServer(version: SoftInstalled): ForkPromise<any> {
-    if (!isWindows()) {
-      return super._stopServer(version)
-    }
-
     return new ForkPromise(async (resolve, reject, on) => {
       const pids = new Set<string>()
       const killPids = new Set<string>()
-      const appPidFile = this.appPidFile()
+      const paths = this.runtimePaths(version)
+      const appPidFile = this.appPidFile(version)
       if (existsSync(appPidFile)) {
         try {
           const pid = await this.readPidFromFile(appPidFile)
@@ -142,7 +175,7 @@ class Mysql extends Base {
         TaskQueue.run(remove, appPidFile).then().catch()
       }
       try {
-        const pid = await this.readPidFromFile()
+        const pid = await this.readPidFromFile(paths.pid)
         if (pid) {
           pids.add(pid)
         }
@@ -153,6 +186,13 @@ class Mysql extends Base {
       try {
         const processList = await StopProcessPidList()
         const ownedMarkers = this.ownedProcessMarkers(version)
+        processList
+          .filter(
+            (item) =>
+              item.COMMAND.includes(paths.config) &&
+              (item.COMMAND.includes('mysqld') || item.COMMAND.includes('mariadbd'))
+          )
+          .forEach((item) => pids.add(item.PID))
         for (const pid of pids) {
           ProcessOwnedPidsByPid(pid, processList, ownedMarkers).forEach((item) =>
             killPids.add(item)
@@ -160,15 +200,12 @@ class Mysql extends Base {
         }
       } catch {}
       if (pids.size > 0) {
-        const v = version?.version?.split('.')?.slice(0, 2)?.join('.') ?? ''
-        const m = join(global.Server.MysqlDir!, `my-${v}.cnf`)
         const bin = join(dirname(version.bin), 'mysqladmin.exe')
         const password = version?.rootPassword ?? 'root'
-
         let port = 3306
-        if (existsSync(m)) {
+        if (existsSync(paths.config)) {
           try {
-            const content = await readFile(m, 'utf8')
+            const content = await readFile(paths.config, 'utf8')
             const config = iniParse(content)
             port = config?.mysqld?.port ?? 3306
           } catch {}
@@ -178,17 +215,18 @@ class Mysql extends Base {
         /**
          * ./mysqladmin.exe --defaults-file="C:\Program Files\FlyEnv-Data\server\mysql\my-5.7.cnf" -v --connect-timeout=1 --shutdown-timeout=1 --protocol=tcp --host="127.0.0.1" -uroot -proot001 shutdown
          */
-        const command = `"${bin}" --defaults-file="${m}" --connect-timeout=1 --shutdown-timeout=1 --protocol=tcp --host="127.0.0.1" --port=${port} -uroot -p${password} shutdown`
+        const command = `"${bin}" --defaults-file="${paths.config}" --connect-timeout=1 --shutdown-timeout=1 --protocol=tcp --host="127.0.0.1" --port=${port} -uroot -p${password} shutdown`
         console.log('mysql _stopServer command: ', command)
-        try {
-          await execPromise(command)
-          success = true
-        } catch (e) {
-          success = false
-          console.log('mysql _stopServer command error: ', e)
+        if (isWindows()) {
+          try {
+            await execPromise(command)
+            success = true
+          } catch (e) {
+            console.log('mysql _stopServer command error: ', e)
+          }
         }
 
-        if (!success) {
+        if (!success && killPids.size > 0) {
           const arr = Array.from(killPids)
           if (arr.length > 0) {
             const str = arr.map((s) => `/pid ${s}`).join(' ')
@@ -196,8 +234,10 @@ class Mysql extends Base {
               await execPromise(`taskkill /f /t ${str}`)
             } catch {}
           }
-        } else {
+        } else if (success) {
           await waitTime(1500)
+        } else if (!isWindows() && killPids.size > 0) {
+          await ProcessKill('-TERM', [...killPids])
         }
       }
 
@@ -222,12 +262,12 @@ class Mysql extends Base {
         )
       })
 
-      const v = version?.version?.split('.')?.slice(0, 2)?.join('.') ?? ''
-      const m = join(global.Server.MysqlDir!, `my-${v}.cnf`)
-      const dataDir = join(global.Server.MysqlDir!, `data-${v}`)
-      const p = join(global.Server.MysqlDir!, 'mysql.pid')
-      const s = join(global.Server.MysqlDir!, 'slow.log')
-      const e = join(global.Server.MysqlDir!, 'error.log')
+      const paths = this.runtimePaths(version)
+      const m = paths.config
+      const dataDir = paths.dataDir
+      const p = paths.pid
+      const s = paths.slowLog
+      const e = paths.errorLog
       if (!existsSync(m)) {
         on({
           'APP-On-Log': AppLog('info', I18nT('appLog.confInit'))
@@ -236,11 +276,41 @@ class Mysql extends Base {
 # Only allow connections from localhost
 bind-address = 127.0.0.1
 sql-mode=NO_ENGINE_SUBSTITUTION
+port=3306
 datadir=${pathFixedToUnix(dataDir)}`
         await writeFile(m, conf)
         on({
           'APP-On-Log': AppLog('info', I18nT('appLog.confInitSuccess', { file: m }))
         })
+      }
+
+      const content = await readFile(m, 'utf8')
+      const config = iniParse(content)
+      const configuredPort = Number.parseInt(`${config?.mysqld?.port ?? 3306}`, 10)
+      const port = Number.isFinite(configuredPort) && configuredPort > 0 ? configuredPort : 3306
+      const ddir = config?.mysqld?.datadir ?? dataDir
+      const listeningPids = isWindows()
+        ? await fetchWindowsProcessPidByPort(`${port}`)
+        : (await fetchUnixProcessPidByPort(`${port}`)).map((item) => item.PID)
+      if (listeningPids.length > 0) {
+        const processList = isWindows()
+          ? await ProcessPidListStrict().catch(() => [])
+          : await StopProcessPidList().catch(() => [])
+        const owner = processList.find((item) => listeningPids.includes(item.PID))
+        const command = owner?.COMMAND ?? ''
+        const ownerVersion = command.match(/my-(\d+\.\d+)\.cnf/i)?.[1]
+        const error = ownerVersion
+          ? I18nT('mysql.portConflictFlyEnv', {
+              version: version.version,
+              port,
+              ownerVersion
+            })
+          : I18nT('mysql.portConflictOther', {
+              version: version.version,
+              port,
+              pid: owner?.PID ?? listeningPids[0]
+            })
+        throw new Error(error)
       }
 
       const unlinkDirOnFail = async () => {
@@ -259,11 +329,6 @@ datadir=${pathFixedToUnix(dataDir)}`
           await mkdirp(baseDir)
           const execEnv = ''
 
-          const content = await readFile(m, 'utf8')
-          const config = iniParse(content)
-          const port = config?.mysqld?.port ?? 3306
-          const ddir = config?.mysqld?.datadir ?? dataDir
-
           if (isWindows()) {
             const execArgs = [
               `--defaults-file="${m}"`,
@@ -272,6 +337,8 @@ datadir=${pathFixedToUnix(dataDir)}`
               '--slow-query-log=ON',
               `--slow-query-log-file="${s}"`,
               `--log-error="${e}"`,
+              `--port=${port}`,
+              `--socket="${paths.socket}"`,
               '--standalone'
             ]
             if (skipGrantTables) {
@@ -318,13 +385,13 @@ datadir=${pathFixedToUnix(dataDir)}`
             }
 
             if (skipGrantTables) {
-              params.push(`--socket=/tmp/mysql.${version.version}.sock`)
+              params.push(`--socket=${paths.socket}`)
               params.push(`--datadir=${ddir}`)
               params.push('--bind-address=127.0.0.1')
               params.push(`--port=${port}`)
               params.push('--skip-grant-tables')
             } else {
-              params.push(`--socket=/tmp/mysql.sock`)
+              params.push(`--socket=${paths.socket}`)
             }
 
             try {
@@ -355,6 +422,8 @@ datadir=${pathFixedToUnix(dataDir)}`
         await chmod(dataDir, '0777')
         let bin = version.bin
         if (isWindows()) {
+          const config = iniParse(await readFile(m, 'utf8'))
+          const port = config?.mysqld?.port ?? 3306
           const params = [
             `--defaults-file="${m}"`,
             `--pid-file="${p}"`,
@@ -362,6 +431,8 @@ datadir=${pathFixedToUnix(dataDir)}`
             '--slow-query-log=ON',
             `--slow-query-log-file="${s}"`,
             `--log-error="${e}"`,
+            `--port=${port}`,
+            `--socket="${paths.socket}"`,
             '--initialize-insecure'
           ]
 
@@ -386,7 +457,7 @@ datadir=${pathFixedToUnix(dataDir)}`
             '--user=mysql',
             `--slow-query-log-file=${s}`,
             `--log-error=${e}`,
-            '--socket=/tmp/mysql.sock'
+            `--socket=${paths.socket}`
           ]
           const installdb = join(version.path, 'bin/mysql_install_db')
           if (existsSync(installdb) && version.num! < 57) {
@@ -971,7 +1042,7 @@ sql-mode=NO_ENGINE_SUBSTITUTION`
         }
       } else {
         const bin = join(dirname(version.bin), 'mysql')
-        const socket = `/tmp/mysql.${version.version}.sock`
+        const socket = this.runtimePaths(version).socket
 
         if (compareVersions(version.version!, '8.0.0') === 1) {
           try {
@@ -1016,7 +1087,7 @@ sql-mode=NO_ENGINE_SUBSTITUTION`
 
       version.rootPassword = password
       try {
-        await super._stopServer(version)
+        await this._stopServer(version)
       } catch {}
 
       resolve(true)

--- a/src/lang/en/mysql.json
+++ b/src/lang/en/mysql.json
@@ -1,5 +1,7 @@
 {
   "port": "TCP Port (Default: 3306)",
+  "portConflictFlyEnv": "MySQL {version} failed to start: port {port} is already occupied by MySQL {ownerVersion}.\nTo run both versions, edit one configuration and use a different port.",
+  "portConflictOther": "MySQL {version} failed to start: port {port} is already occupied by another process (PID {pid}).\nClose the process using the port or change the MySQL port.",
   "key_buffer_size": "Buffer size for indexing",
   "query_cache_size": "Query cache, please set to 0 if not enabled",
   "tmp_table_size": "Temporary table cache size",

--- a/src/lang/zh/mysql.json
+++ b/src/lang/zh/mysql.json
@@ -1,5 +1,7 @@
 {
   "port": "端口号. 默认为3306",
+  "portConflictFlyEnv": "MySQL {version} 启动失败：端口 {port} 已被 MySQL {ownerVersion} 占用。\n如需同时运行，请编辑其中一个版本的配置并使用不同端口。",
+  "portConflictOther": "MySQL {version} 启动失败：端口 {port} 已被其他进程占用（PID {pid}）。\n请关闭占用端口的程序，或修改当前 MySQL 版本的端口。",
   "key_buffer_size": "用于索引的缓冲区大小",
   "query_cache_size": "查询缓存,不开启请设为0",
   "tmp_table_size": "临时表缓存大小",

--- a/src/main/core/MCPContextResolver.ts
+++ b/src/main/core/MCPContextResolver.ts
@@ -402,6 +402,9 @@ export default class MCPContextResolver {
 
   private deriveSocket(flag: string, version: SoftInstalled, configText: string, port: number) {
     if (flag === 'mysql' || flag === 'mariadb') {
+      if (flag === 'mysql' && version?.version) {
+        return join(global.Server.MysqlDir!, `mysql-${mysqlVersionPrefix(version.version)}.sock`)
+      }
       if (version?.version) {
         return `/tmp/mysql.${version.version}.sock`
       }

--- a/src/main/core/MCPTools.ts
+++ b/src/main/core/MCPTools.ts
@@ -19,7 +19,6 @@ const SINGLE_INSTANCE_SERVICES = new Set<string>([
   'nginx',
   'apache',
   'caddy',
-  'mysql',
   'mariadb',
   'postgresql',
   'clickhouse',
@@ -526,7 +525,7 @@ export class MCPTools {
   async startService(flag: string, version?: string): Promise<any> {
     this.assertLifecycleFlag(flag, 'start')
     const v = await this.pickVersion(flag, version)
-    // 单实例服务（nginx/mysql/redis... isOnlyRunOne）：启动某版本即「切到该版本」——
+    // 单实例服务（nginx/redis... isOnlyRunOne）：启动某版本即「切到该版本」——
     // 与 FlyEnv UI 的 onItemStart 行为对齐，先停掉其它正在运行的版本。
     // 多实例运行时（php/node/python... 语言类）：多版本可并存，不停其它。
     if (SINGLE_INSTANCE_SERVICES.has(flag)) {

--- a/src/render/components/Mysql/Config.vue
+++ b/src/render/components/Mysql/Config.vue
@@ -1,41 +1,56 @@
 <template>
-  <Conf
-    ref="conf"
-    :type-flag="'mysql'"
-    :default-conf="defaultConf"
-    :file="file"
-    :file-ext="'cnf'"
-    :show-commond="true"
-    @on-type-change="onTypeChange"
+  <el-drawer
+    v-model="show"
+    size="75%"
+    :destroy-on-close="true"
+    :with-header="false"
+    :close-on-click-modal="false"
+    @closed="closedFn"
   >
-    <template #common>
-      <Common :setting="commonSetting" />
-    </template>
-  </Conf>
+    <div class="host-vhost">
+      <div class="nav pl-3 pr-5">
+        <div class="left" @click="show = false">
+          <yb-icon :svg="import('@/svg/delete.svg?raw')" class="top-back-icon" />
+          <span class="ml-3 title truncate">MySQL {{ version.version }} - {{ version.path }}</span>
+        </div>
+      </div>
+      <Conf
+        ref="conf"
+        :type-flag="'mysql'"
+        :default-conf="defaultConf"
+        :file="file"
+        :file-ext="'cnf'"
+        :show-commond="true"
+        :version="version"
+        @on-type-change="onTypeChange"
+      >
+        <template #common>
+          <Common :setting="commonSetting" />
+        </template>
+      </Conf>
+    </div>
+  </el-drawer>
 </template>
 
 <script lang="ts" setup>
   import { computed, ref, watch, Ref, reactive } from 'vue'
-  import Conf from '@/components/Conf/index.vue'
+  import Conf from '@/components/Conf/drawer.vue'
   import Common from '@/components/Conf/common.vue'
   import type { CommonSetItem } from '@/components/Conf/setup'
   import { I18nT } from '@lang/index'
   import { debounce } from 'lodash-es'
-  import { AppStore } from '@/store/app'
+  import { AsyncComponentSetup } from '@/util/AsyncComponent'
+  import type { SoftInstalled } from '@/store/brew'
   import { uuid } from '@/util/Index'
   import { join } from '@/util/path-browserify'
   import { IniParse } from '@/util/IniParse'
-
-  const appStore = AppStore()
+  const props = defineProps<{ version: SoftInstalled }>()
+  const { show, onClosed, onSubmit, closedFn } = AsyncComponentSetup()
   const conf = ref()
   const commonSetting: Ref<CommonSetItem[]> = ref([])
 
-  const currentVersion = computed(() => {
-    return appStore.config?.server?.mysql?.current?.version
-  })
-
   const vm = computed(() => {
-    return currentVersion?.value?.split('.')?.slice(0, 2)?.join('.')
+    return props.version?.version?.split('.')?.slice(0, 2)?.join('.') ?? ''
   })
 
   const file = computed(() => {
@@ -54,6 +69,7 @@
 # Only allow connections from localhost
 bind-address = 127.0.0.1
 sql-mode=NO_ENGINE_SUBSTITUTION
+port=3306
 datadir=${dataDir}`
   })
 
@@ -221,4 +237,6 @@ datadir=${dataDir}`
       getCommonSetting()
     }
   }
+
+  defineExpose({ show, onClosed, onSubmit })
 </script>

--- a/src/render/components/Mysql/Index.vue
+++ b/src/render/components/Mysql/Index.vue
@@ -2,7 +2,7 @@
   <div class="soft-index-panel main-right-panel">
     <el-radio-group v-model="tab" class="mt-3">
       <template v-for="(item, _index) in tabs" :key="_index">
-        <template v-if="_index === 5">
+        <template v-if="_index === 2">
           <el-badge type="success" is-dot :hidden="!groupRun">
             <el-radio-button :label="item" :value="_index"></el-radio-button>
           </el-badge>
@@ -48,6 +48,22 @@
             <SetUp width="17" height="17" />
             <span class="ml-3">{{ I18nT('mysql.manage') }}</span>
           </li>
+          <li @click.stop="openDir(row.path)">
+            <yb-icon :svg="import('@/svg/folder.svg?raw')" width="17" height="17" />
+            <span class="ml-3">{{ I18nT('base.open') }}</span>
+          </li>
+          <li @click.stop="toConfig(row)">
+            <yb-icon :svg="import('@/svg/config.svg?raw')" width="17" height="17" />
+            <span class="ml-3">{{ I18nT('base.configFile') }}</span>
+          </li>
+          <li @click.stop="toLogs(row, 'error')">
+            <yb-icon :svg="import('@/svg/log.svg?raw')" width="17" height="17" />
+            <span class="ml-3">{{ I18nT('common.label.errorLog') }}</span>
+          </li>
+          <li @click.stop="toLogs(row, 'slow')">
+            <yb-icon :svg="import('@/svg/log.svg?raw')" width="17" height="17" />
+            <span class="ml-3">{{ I18nT('base.slowLog') }}</span>
+          </li>
         </template>
       </Service>
       <Manager
@@ -56,10 +72,7 @@
         url="https://dev.mysql.com/downloads/mysql/"
         title="Mysql"
       ></Manager>
-      <Config v-if="tab === 2"></Config>
-      <Logs v-if="tab === 3" type="error"></Logs>
-      <Logs v-if="tab === 4" type="slow"></Logs>
-      <Group v-if="tab === 5"></Group>
+      <Group v-if="tab === 2"></Group>
     </div>
   </div>
 </template>
@@ -67,8 +80,6 @@
 <script lang="ts" setup>
   import { computed, ref } from 'vue'
   import Service from '../ServiceManager/index.vue'
-  import Config from './Config.vue'
-  import Logs from './Logs.vue'
   import Manager from '../VersionManager/index.vue'
   import Group from './Group/Index.vue'
   import { MysqlStore } from './mysql'
@@ -79,18 +90,15 @@
   import { AsyncComponentShow } from '@/util/AsyncComponent'
   import { BrewStore } from '@/store/brew'
   import { MySQLManage } from '@/components/Mysql/Manage/manage'
+  import { shell } from '@/util/NodeFn'
 
   const brewStore = BrewStore()
   const mysqlStore = MysqlStore()
   const { tab, checkVersion } = AppModuleSetup('mysql')
-  const tabs = [
-    I18nT('base.service'),
-    I18nT('base.versionManager'),
-    I18nT('base.configFile'),
-    I18nT('base.log'),
-    I18nT('base.slowLog'),
-    I18nT('base.group')
-  ]
+  const tabs = [I18nT('base.service'), I18nT('base.versionManager'), I18nT('base.group')]
+  if (tab.value > tabs.length - 1) {
+    tab.value = 0
+  }
   const groupRun = computed(() => {
     return mysqlStore.all.some((a) => a.version.running)
   })
@@ -103,6 +111,28 @@
         item
       }).then()
     })
+  }
+
+  let ConfigVM: any
+  import('./Config.vue').then((res) => {
+    ConfigVM = res.default
+  })
+
+  let LogsVM: any
+  import('./Logs.vue').then((res) => {
+    LogsVM = res.default
+  })
+
+  const toConfig = (item: ModuleInstalledItem) => {
+    AsyncComponentShow(ConfigVM, { version: item }).then()
+  }
+
+  const openDir = (path: string) => {
+    shell.openPath(path)
+  }
+
+  const toLogs = (item: ModuleInstalledItem, type: 'error' | 'slow') => {
+    AsyncComponentShow(LogsVM, { version: item, type }).then()
   }
 
   brewStore

--- a/src/render/components/Mysql/Logs.vue
+++ b/src/render/components/Mysql/Logs.vue
@@ -1,24 +1,64 @@
 <template>
-  <div class="module-config">
-    <el-card>
-      <LogVM ref="log" :log-file="filepath" />
-      <template #footer>
-        <ToolVM :log="log" />
-      </template>
-    </el-card>
-  </div>
+  <el-drawer
+    v-model="show"
+    size="75%"
+    :destroy-on-close="true"
+    :with-header="false"
+    :close-on-click-modal="false"
+    @closed="closedFn"
+  >
+    <div class="host-vhost">
+      <div class="nav pl-3 pr-5">
+        <div class="left" @click="show = false">
+          <yb-icon :svg="import('@/svg/delete.svg?raw')" class="top-back-icon" />
+          <span class="ml-3 title truncate">{{ title }} - MySQL {{ version.version }}</span>
+        </div>
+      </div>
+      <div class="main-wapper">
+        <LogVM ref="log" :log-file="filepath" />
+      </div>
+      <ToolVM :log="log" />
+    </div>
+  </el-drawer>
 </template>
 
 <script lang="ts" setup>
-  import { ref } from 'vue'
+  import { computed, ref } from 'vue'
   import LogVM from '@/components/Log/index.vue'
   import ToolVM from '@/components/Log/tool.vue'
+  import { I18nT } from '@lang/index'
+  import { AsyncComponentSetup } from '@/util/AsyncComponent'
+  import type { SoftInstalled } from '@/store/brew'
   import { join } from '@/util/path-browserify'
+  import IPC from '@/util/IPC'
 
   const props = defineProps<{
     type: string
+    version: SoftInstalled
   }>()
 
+  const { show, onClosed, onSubmit, closedFn } = AsyncComponentSetup()
   const log = ref()
-  const filepath = ref(join(window.Server.MysqlDir ?? '', `${props.type}.log`))
+  const title = computed(() => (props.type === 'slow' ? I18nT('base.slowLog') : I18nT('base.log')))
+  const versionKey = computed(
+    () => props.version?.version?.split('.')?.slice(0, 2)?.join('.') ?? ''
+  )
+  const filepath = ref(
+    join(window.Server.MysqlDir ?? '', `mysql-${versionKey.value}-${props.type}.log`)
+  )
+
+  IPC.send('app-fork:mysql', 'getLogFiles', JSON.parse(JSON.stringify(props.version))).then(
+    (key: string, res: any) => {
+      IPC.off(key)
+      const name = props.type === 'slow' ? 'slow' : 'error'
+      const file = (res?.data ?? []).find(
+        (item: { name: string; path: string }) => item.name === name
+      )
+      if (file?.path) {
+        filepath.value = file.path
+      }
+    }
+  )
+
+  defineExpose({ show, onClosed, onSubmit })
 </script>

--- a/src/render/components/Mysql/Module.ts
+++ b/src/render/components/Mysql/Module.ts
@@ -10,6 +10,7 @@ const module: AppModuleItem = {
   aside: defineAsyncComponent(() => import('./aside.vue')),
   asideIndex: 6,
   isService: true,
+  isOnlyRunOne: false,
   isTray: true
 }
 export default module

--- a/src/render/components/ServiceManager/setup.ts
+++ b/src/render/components/ServiceManager/setup.ts
@@ -3,7 +3,6 @@ import { AppStore } from '@/store/app'
 import { BrewStore, SoftInstalled } from '@/store/brew'
 import { ServiceActionStore } from '@/components/ServiceManager/EXT/store'
 import { MessageError } from '@/util/Element'
-import { MysqlStore } from '@/components/Mysql/mysql'
 import { AsyncComponentShow } from '@/util/AsyncComponent'
 import type { AllAppModule } from '@/core/type'
 import { shell } from '@/util/NodeFn'
@@ -51,7 +50,7 @@ export const Setup = (typeFlag: AllAppModule) => {
 
   const versionRunning = computed(() => {
     const module = brewStore.module(typeFlag)
-    return module.starting || module.installed.some((item) => item.running)
+    return module.starting
   })
 
   const isInEnv = (item: SoftInstalled) => {
@@ -99,6 +98,9 @@ export const Setup = (typeFlag: AllAppModule) => {
     if (versionRunning.value) {
       return
     }
+    if (item.running) {
+      return
+    }
     let action: any
     switch (flag) {
       case 'stop':
@@ -115,14 +117,6 @@ export const Setup = (typeFlag: AllAppModule) => {
       if (typeof res === 'string') {
         MessageError(res)
       } else {
-        if (typeFlag === 'mysql') {
-          const mysqlStore = MysqlStore()
-          if (flag === 'stop') {
-            mysqlStore.groupStop().then()
-          } else {
-            mysqlStore.groupStart().then()
-          }
-        }
       }
     })
   }

--- a/src/render/core/Module/ModuleInstalledItem.ts
+++ b/src/render/core/Module/ModuleInstalledItem.ts
@@ -154,7 +154,10 @@ export class ModuleInstalledItem implements SoftInstalled {
         return
       }
       const module = BrewStore().module(this.typeFlag)
-      if (module.starting || module.installed.some((item) => item.running)) {
+      if (
+        module.starting ||
+        (this.typeFlag !== 'mysql' && module.installed.some((item) => item.running))
+      ) {
         resolve(true)
         return
       }


### PR DESCRIPTION
## 变更概述

将 MySQL 多版本管理改造为类似 PHP 的版本级管理方式，使每个 MySQL 版本拥有独立的配置、运行文件和日志入口。

## 主要变更

- 移除 MySQL 顶部的“配置文件”“日志”“慢日志”标签。
- 在每个 MySQL 版本的操作列中增加：
  - 编辑配置
  - 查看错误日志
  - 查看慢日志
- 配置编辑支持文本模式和图形模式。
- 配置和日志操作均基于明确的 MySQL 版本，不再依赖全局当前版本。
- 按版本隔离以下文件：
  - 配置文件
  - 数据目录
  - PID 文件
  - 错误日志
  - 慢日志
  - Socket 文件
- 所有 MySQL 版本默认端口仍为 `3306`。
- 启动前检查端口占用，端口冲突时显示明确提示。
- 允许多个 MySQL 版本同时运行，但需要使用不同端口。
- 停止、重启和状态检查只作用于对应版本，不影响其他 MySQL 实例。
- 日志支持查看运行中的实时日志，也支持查看未运行版本的历史日志。
- 保留 Windows 测试构建工作流。

## 端口冲突处理

当端口被其他 MySQL 版本占用时，会提示占用的版本以及修改端口的建议。

当端口被普通程序占用时，会尽可能显示占用进程的 PID。

不会自动停止其他程序、自动停止其他 MySQL 版本，也不会自动修改端口。

## 验证情况

- 已通过修改文件的 ESLint 检查。
- 已通过生命周期单实例测试。
- 已通过 `git diff --check`。
- 已确认配置、日志、PID 和运行状态逻辑按版本隔离。
- 已确认 Windows 测试构建工作流文件保留。

## 提交记录

本分支已整理为两个逻辑提交：

1. 完善 MySQL 多版本独立管理和端口冲突处理
2. 新增 Windows 测试构建工作流

## 注意事项

当前 Windows 测试构建工作流监听：

```yaml
feature/mysql-multi-instance-port