### PR TITLE
fix(podman): replace invalid --rosetta flag with containers.conf drop-in

### DIFF
--- a/src/fork/module/Podman/index.ts
+++ b/src/fork/module/Podman/index.ts
@@ -1,17 +1,81 @@
 import { Base } from '../Base'
 import { ForkPromise } from '@shared/ForkPromise'
 import type { SoftInstalled } from '@shared/app'
-import { tmpdir } from 'node:os'
+import { tmpdir, homedir } from 'node:os'
 import { join } from 'node:path'
-import { uuid, execPromiseWithEnv, readFile, remove, existsSync, waitTime } from '../../Fn'
-import { isLinux, isWindows } from '@shared/utils'
+import {
+  uuid,
+  execPromiseWithEnv,
+  readFile,
+  writeFile,
+  remove,
+  existsSync,
+  mkdirp,
+  waitTime
+} from '../../Fn'
+import { isLinux, isMacOS, isWindows } from '@shared/utils'
 import axios from 'axios'
 import { fetchTags } from './image'
+
+/**
+ * Podman 5.1.0 introduced the Rosetta toggle, read from containers.conf
+ * ([machine] rosetta) when a machine is created or started. There is no
+ * `--rosetta` CLI flag on `podman machine init` in any Podman version.
+ */
+const PODMAN_ROSETTA_MIN_VERSION = '5.1.0'
+
+const compareVersion = (a: string, b: string): number => {
+  const pa = a.split('.').map((n) => parseInt(n, 10) || 0)
+  const pb = b.split('.').map((n) => parseInt(n, 10) || 0)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0
+    const y = pb[i] ?? 0
+    if (x !== y) {
+      return x - y
+    }
+  }
+  return 0
+}
 
 class Podman extends Base {
   constructor() {
     super()
     this.type = 'podman'
+  }
+
+  /**
+   * Write the Rosetta preference to a drop-in containers.conf so Podman
+   * (>= 5.1.0, Apple Silicon) applies it on machine init/start.
+   * The drop-in file never touches the user's own containers.conf
+   * and can be rolled back by deleting it.
+   */
+  private async applyRosettaConfig(enable: boolean) {
+    try {
+      let version = ''
+      const tmp = join(tmpdir(), `${uuid()}.txt`)
+      try {
+        await execPromiseWithEnv(`podman --version > "${tmp}" 2>&1`)
+        version = ((await readFile(tmp, 'utf-8')) || '').split(' ')?.pop()?.trim() ?? ''
+      } catch {
+        version = ''
+      } finally {
+        if (existsSync(tmp)) {
+          await remove(tmp)
+        }
+      }
+      const m = version.match(/(\d+\.\d+\.\d+)/)
+      if (!m || compareVersion(m[1], PODMAN_ROSETTA_MIN_VERSION) < 0) {
+        return
+      }
+      const confDir = join(homedir(), '.config', 'containers', 'containers.conf.d')
+      await mkdirp(confDir)
+      await writeFile(
+        join(confDir, 'flyenv-podman.conf'),
+        `[machine]\nrosetta = ${enable ? 'true' : 'false'}\n`
+      )
+    } catch (e) {
+      console.log('applyRosettaConfig error: ', e)
+    }
   }
 
   private async getComposeCommand(): Promise<string> {
@@ -279,8 +343,8 @@ class Podman extends Base {
         } else {
           args.push('--rootful=false')
         }
-        if (rosetta) {
-          args.push('--rosetta')
+        if (isMacOS()) {
+          await this.applyRosettaConfig(!!rosetta)
         }
         if (identityPath) {
           args.push(`--identity-path "${identityPath}"`)

--- a/src/render/components/Podman/machine/machineAdd.vue
+++ b/src/render/components/Podman/machine/machineAdd.vue
@@ -32,7 +32,7 @@
         <el-form-item :label="I18nT('podman.rootful')" prop="rootful">
           <el-switch v-model="form.rootful" />
         </el-form-item>
-        <el-form-item v-if="!isEdit" :label="I18nT('podman.rosetta')" prop="rosetta">
+        <el-form-item v-if="!isEdit && isMacOSArm" :label="I18nT('podman.rosetta')" prop="rosetta">
           <el-switch v-model="form.rosetta" />
         </el-form-item>
         <el-form-item v-if="!isEdit" :label="I18nT('podman.identityPath')" prop="identityPath">
@@ -63,6 +63,9 @@
 
   const props = defineProps<{ item?: any }>()
   const isEdit = !!props.item
+
+  // Rosetta is only supported by Podman on Apple Silicon (arm64)
+  const isMacOSArm = computed(() => window.Server.isMacOS && window.Server.isArmArch)
 
   const visible = ref(true)
   const submitting = ref(false)


### PR DESCRIPTION
Fixes #800.

## Root cause

`podman machine init` has **no `--rosetta` CLI flag in any Podman version** — verified against upstream sources (v4.6.0 / v4.9.0 / v5.1.0 / v5.6.0): the full flag list registered in `cmd/podman/machine/init.go` never includes `rosetta`, and the `podman-machine-init` man page never mentions it. Enabling the option therefore always failed with `unknown flag: --rosetta`, regardless of the installed Podman version.

Rosetta is instead controlled through `containers.conf` (`[machine] rosetta`), read engine-side when a machine is created/started, and only honored on Apple Silicon. That toggle exists since **Podman 5.1.0**.

## Changes

- **Remove the invalid `--rosetta` flag** from the `podman machine init` command.
- **Write the Rosetta preference to a drop-in file** `~/.config/containers/containers.conf.d/flyenv-podman.conf` (`[machine] rosetta = true/false`):
  - the user's own `containers.conf` is never modified, and rolling back is just deleting the drop-in;
  - written explicitly as `true`/`false` so switching the toggle off actually takes effect (engine default is `true`);
  - only applied when `podman --version` >= 5.1.0 (the config is ignored by older versions);
  - failures are logged and non-fatal — machine creation proceeds.
- **Show the Rosetta switch only on macOS arm64** (`window.Server.isMacOS && window.Server.isArmArch`); on other platforms the engine forces rosetta off, so the switch was misleading.

## Verification

- TypeScript syntax check + Prettier (project config) pass on both files.
- Windows/Linux paths untouched: the drop-in write is guarded by `isMacOS()`, and the UI switch is hidden on non-arm64.

> Note for reviewers: Rosetta semantics are global in Podman (a containers.conf setting, not a per-machine flag), so the drop-in intentionally reflects the UI toggle for machines created/started afterwards.

---

## 中文说明

### 根因

`podman machine init` 在**任何 Podman 版本中都没有 `--rosetta` 这个命令行参数**——已对照上游源码核实（v4.6.0 / v4.9.0 / v5.1.0 / v5.6.0）：`cmd/podman/machine/init.go` 注册的完整参数清单从未包含 `rosetta`，`podman-machine-init` 手册页也从未提及。因此只要勾选 Rosetta 选项，必然报 `unknown flag: --rosetta`，与所装 Podman 版本无关。

Rosetta 实际由 `containers.conf` 的 `[machine] rosetta` 控制：Podman 在创建/启动虚拟机时由引擎读取，且仅在 Apple Silicon（arm64）上生效。该配置自 **Podman 5.1.0** 起支持。

### 改动

- **从 `podman machine init` 命令中移除无效的 `--rosetta` 参数**。
- **将 Rosetta 偏好写入 drop-in 文件** `~/.config/containers/containers.conf.d/flyenv-podman.conf`（`[machine] rosetta = true/false`）：
  - 完全不修改用户自己的 `containers.conf`，回滚只需删除该 drop-in 文件；
  - 显式写入 `true`/`false` 两个值，保证"关闭"开关真正生效（引擎默认值为 `true`）；
  - 仅在 `podman --version` >= 5.1.0 时写入（旧版本会忽略该配置）；
  - 写入失败仅记录日志、不中断——虚拟机创建流程照常进行。
- **Rosetta 开关仅在 macOS arm64 上显示**（`window.Server.isMacOS && window.Server.isArmArch`）；其他平台引擎侧会强制关闭 rosetta，继续显示开关有误导性。

### 验证

- 两个文件均通过 TypeScript 语法检查与项目 Prettier 格式校验。
- Windows/Linux 路径未受影响：drop-in 写入由 `isMacOS()` 守卫，非 arm64 不显示开关。

> 给评审者的说明：Rosetta 在 Podman 中是全局语义（containers.conf 配置项，而非每台虚拟机独立的参数），因此 drop-in 反映的是 UI 开关的当前值，对之后创建/启动的虚拟机生效。
